### PR TITLE
fix(sanity): live preview service is called before be initialized

### DIFF
--- a/packages/sanity/preview-kit/src/live-query-provider.component.ts
+++ b/packages/sanity/preview-kit/src/live-query-provider.component.ts
@@ -1,7 +1,7 @@
 import {
-  afterNextRender,
   ChangeDetectionStrategy,
   Component,
+  effect,
   inject,
   input,
 } from '@angular/core';
@@ -24,7 +24,7 @@ export class LiveQueryProviderComponent {
   private livePreviewService = inject(LivePreviewService);
 
   constructor() {
-    afterNextRender(() => {
+    effect(() => {
       this.livePreviewService.initialize(this.token());
     });
   }


### PR DESCRIPTION
## PR Checklist

## What is the new behavior?

This PR fixes a timing issue with the LivePreviewService initialization. Previously, the service was initialized using `afterNextRender()`, which could potentially cause race conditions or initialization delays. The change replaces this with Angular's `effect()`, ensuring that:

1. The initialization happens reactively when the token input is available
2. The service is properly initialized before any live preview functionality is used
3. The initialization will re-run if the token changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The change from `afterNextRender` to `effect` is a more idiomatic way to handle reactive initialization in Angular's signals-based architecture. This ensures better predictability of when the live preview service is initialized and maintains reactivity with the token input.

## What gif best describes this PR or how it makes you feel?

[A "Perfect Timing" gif would be appropriate here since this PR fixes a timing-related issue]
<img src="https://media3.giphy.com/media/pqMSyHmekA1Qe7Utp7/giphy.gif?cid=bd3ea57eiobpr5iylm6td8u72utrajhuhuirv7t4zgnvfoo1&ep=v1_gifs_search&rid=giphy.gif&ct=g"/>