### PR TITLE
fix(analog-sanity-blog): make settings nullable on server request

### DIFF
--- a/apps/analog-sanity-blog-example/src/app/pages/(blog)/(home).server.ts
+++ b/apps/analog-sanity-blog-example/src/app/pages/(blog)/(home).server.ts
@@ -18,7 +18,7 @@ export const load = async ({ event }: PageServerLoad) => {
   ]);
 
   return {
-    settings: (settings ?? {}) as NonNullable<typeof settings>,
+    settings,
     posts: posts,
     draftMode,
     token: draftMode ? readToken : '',

--- a/apps/analog-sanity-blog-example/src/app/pages/(blog)/home-page.component.ts
+++ b/apps/analog-sanity-blog-example/src/app/pages/(blog)/home-page.component.ts
@@ -129,7 +129,7 @@ export class HeroPostComponent {
         </aside>
       }
     </div>
-    <footer blog-footer [footer]="settings().footer"></footer>
+    <footer blog-footer [footer]="settings()?.footer"></footer>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })


### PR DESCRIPTION
## PR Checklist

## What is the new behavior?

This PR fixes a type safety issue in the Analog Sanity Blog example where the settings object from Sanity could be null. The changes include:

1. Removing the non-null assertion in the server load function to properly handle null settings
2. Adding optional chaining operator when accessing settings properties in the template
3. Ensuring type safety throughout the settings object usage

These changes prevent runtime errors when Sanity returns null settings and improve the overall robustness of the application.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This change improves error handling and type safety in the Analog Sanity Blog example. Previously, the application would fail when Sanity returned null settings because we were forcefully casting it as non-nullable. The fix properly handles nullable settings throughout the application flow.

## What gif best describes this PR or how it makes you feel?

<img src="https://media0.giphy.com/media/v1.Y2lkPWJkM2VhNTdlOGlvbjQ0Y2d3NHUxYXRjZm45ZGYxYm9yYTcydHZlcmhhOXA1dWt2aCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/2KAGlmkPywhZS/giphy.gif"/>