### PR TITLE
fix(sanity): live preview service is called before be initialized in v18

### DIFF
--- a/packages/sanity/preview-kit/src/live-preview.service.ts
+++ b/packages/sanity/preview-kit/src/live-preview.service.ts
@@ -86,11 +86,15 @@ export class LivePreviewService {
   private docsInUse = new Map<string, ContentSourceMap['documents'][number]>();
   private lastMutatedDocumentId$ = new BehaviorSubject<string | null>(null);
   private turboIds$ = new BehaviorSubject<string[]>([]);
-  private isInitialized = false;
+  #isInitialized = false;
   private warnedAboutCrossDatasetReference = false;
 
+  get isInitialized(): boolean {
+    return this.#isInitialized;
+  }
+
   initialize(token: string): void {
-    if (this.isInitialized) {
+    if (this.#isInitialized) {
       console.warn('LiveStoreService is already initialized');
       return;
     }
@@ -126,11 +130,11 @@ export class LivePreviewService {
       this.syncWithPresentationToolIfPresent();
     }
 
-    this.isInitialized = true;
+    this.#isInitialized = true;
   }
 
   private checkInitialization(): void {
-    if (!this.isInitialized) {
+    if (!this.#isInitialized) {
       throw new Error(
         'LiveStoreService is not initialized. Call initialize(token) first.',
       );

--- a/packages/sanity/preview-kit/src/live-query-provider.component.ts
+++ b/packages/sanity/preview-kit/src/live-query-provider.component.ts
@@ -1,4 +1,5 @@
 import {
+  afterNextRender,
   ChangeDetectionStrategy,
   Component,
   effect,
@@ -24,8 +25,18 @@ export class LiveQueryProviderComponent {
   private livePreviewService = inject(LivePreviewService);
 
   constructor() {
+    // Initialization for Angular v18
+    afterNextRender(() => {
+      if (!this.livePreviewService.isInitialized) {
+        this.livePreviewService.initialize(this.token());
+      }
+    });
+
+    // Initialization for Angular v19
     effect(() => {
-      this.livePreviewService.initialize(this.token());
+      if (!this.livePreviewService.isInitialized) {
+        this.livePreviewService.initialize(this.token());
+      }
     });
   }
 }


### PR DESCRIPTION
## PR Checklist

## What is the new behavior?

This PR fixes a timing issue with the LivePreviewService initialization in v18 introduced by #9. Previously, the service was initialized `effect()`, which cause race conditions or initialization delays. The change add this with Angular's `afterNextRender()` that previously worked in v19 while it maintains the effect for v19, ensuring that:

1. The initialization happens reactively when the token input is available
2. The service is properly initialized before any live preview functionality is used
3. The initialization will re-run if the token changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What gif best describes this PR or how it makes you feel?

[A "Perfect Timing" gif would be appropriate here since this PR fixes a timing-related issue]
<img src="https://media3.giphy.com/media/pqMSyHmekA1Qe7Utp7/giphy.gif?cid=bd3ea57eiobpr5iylm6td8u72utrajhuhuirv7t4zgnvfoo1&ep=v1_gifs_search&rid=giphy.gif&ct=g"/>