### PR TITLE
fix: keep analog example dist package-local

### DIFF
--- a/apps/analog-sanity-blog-example/angular.json
+++ b/apps/analog-sanity-blog-example/angular.json
@@ -14,7 +14,7 @@
           "options": {
             "main": "src/main.ts",
             "configFile": "vite.config.ts",
-            "outputPath": "../../dist/apps/analog-sanity-blog-example/client",
+            "outputPath": "analog-sanity-blog-example/dist/client",
             "tsConfig": "tsconfig.app.json"
           },
           "configurations": {

--- a/apps/analog-sanity-blog-example/tsconfig.app.json
+++ b/apps/analog-sanity-blog-example/tsconfig.app.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../dist/out-tsc",
+    "outDir": "dist/out-tsc",
     "types": [],
     "useDefineForClassFields": false
   },

--- a/apps/analog-sanity-blog-example/vite.config.ts
+++ b/apps/analog-sanity-blog-example/vite.config.ts
@@ -22,6 +22,12 @@ export default defineConfig(({ mode }) => {
     plugins: [
       analog({
         nitro: {
+          alias: {
+            '@/analog-sanity-blog-example/sanity': resolve(
+              configDir,
+              'src/sanity/lib/index.ts',
+            ),
+          },
           static: false,
           routeRules: {
             '/': { prerender: false, isr: 60 },

--- a/apps/analog-sanity-blog-example/vite.config.ts
+++ b/apps/analog-sanity-blog-example/vite.config.ts
@@ -15,27 +15,13 @@ export default defineConfig(({ mode }) => {
   }
 
   return {
-    root: configDir,
-    cacheDir: `../../node_modules/.vite`,
-
     build: {
-      outDir: '../../dist/apps/analog-sanity-blog-example/client',
-      reportCompressedSize: true,
+      outDir: 'dist/client',
       target: ['es2022'],
     },
     plugins: [
       analog({
-        workspaceRoot: resolve(configDir, '../..'),
         nitro: {
-          rootDir: configDir,
-          srcDir: resolve(configDir, 'src/server'),
-          scanDirs: [resolve(configDir, 'src/server')],
-          alias: {
-            '@/analog-sanity-blog-example/sanity': resolve(
-              configDir,
-              'src/sanity/lib/index.ts',
-            ),
-          },
           static: false,
           routeRules: {
             '/': { prerender: false, isr: 60 },


### PR DESCRIPTION
## PR Checklist

Keeps the Analog Sanity blog example's generated files inside the example package instead of writing app build output into repository-level dist folders.

Closes N/A

## What is the new behavior?

- The Analog example's Angular builder and Vite build output resolve to `apps/analog-sanity-blog-example/dist`.
- The app TypeScript output also resolves under the example package.
- Redundant Vite/Analog/Nitro directory settings were removed now that package-local defaults are used.
- The root `tsconfig.base.json` path plugins remain because they are still needed for workspace package imports.
- The Nitro alias for `@/analog-sanity-blog-example/sanity` remains because the dev worker used by e2e needs it at runtime.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validated with:

- `pnpm --filter analog-sanity-blog-example build`
- `pnpm --filter analog-sanity-blog-example exec ng build`
- `pnpm turbo run e2e --filter=sanity-presentation-e2e`
- `git diff --check`

Both build entry points emit under `apps/analog-sanity-blog-example/dist`; no `apps/dist` or root `dist/apps/analog-sanity-blog-example` directory is produced.

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

