### PR TITLE
chore: remove stale minimum release age exclude

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,8 +5,6 @@ packages:
 overrides:
   '@babel/traverse': 7.26.4
   '@portabletext/editor': 1.15.3
-minimumReleaseAgeExclude:
-  - '@types/node@22.19.20'
 allowBuilds:
   '@parcel/watcher': true
   '@swc/core': true


### PR DESCRIPTION
## PR Checklist

Removes a stale `minimumReleaseAgeExclude` entry from `pnpm-workspace.yaml`. The workspace does not currently configure `minimum-release-age`, so the exclusion is inert.

Closes #

## What is the new behavior?

`pnpm-workspace.yaml` no longer excludes `@types/node@22.19.20` from minimum release age checks. The remaining overrides and build approvals are unchanged.

Validation:

- `pnpm config get minimum-release-age` returns `undefined`
- `pnpm install --lockfile-only --ignore-scripts`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is a config cleanup only; `pnpm-lock.yaml` did not change.

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
