### PR TITLE
fix(netlify): restore sanity example deployment

### DIFF
--- a/apps/sanity-example/package.json
+++ b/apps/sanity-example/package.json
@@ -31,6 +31,7 @@
     "@angular-devkit/build-angular": "~19.0.4",
     "@angular/cli": "~19.0.4",
     "@angular/compiler-cli": "~19.0.3",
+    "@netlify/angular-runtime": "4.0.0",
     "@tailwindcss/typography": "^0.5.13",
     "@types/express": "4.17.14",
     "@types/leaflet": "^1.9.12",

--- a/apps/sanity-example/src/app/components/currency-amount.component.ts
+++ b/apps/sanity-example/src/app/components/currency-amount.component.ts
@@ -4,6 +4,7 @@ import {
   computed,
   inject,
   PLATFORM_ID,
+  type ProviderToken,
 } from '@angular/core';
 import { isPlatformBrowser, isPlatformServer } from '@angular/common';
 
@@ -12,17 +13,23 @@ import { type Request as ExpressRequest } from 'express';
 
 import { REQUEST } from '../../server.tokens';
 
+const NETLIFY_REQUEST = 'netlify.request' as unknown as ProviderToken<Request>;
+
 // FIXME: request token isn't injected with `ng serve` see: https://github.com/angular/angular-cli/issues/26323
 const getLanguagesFn = () => {
   const platformId = inject(PLATFORM_ID);
   const expressRequest = inject<ExpressRequest>(REQUEST, { optional: true });
+  const netlifyRequest = inject<Request>(NETLIFY_REQUEST, { optional: true });
 
   return () => {
-    if (isPlatformServer(platformId) && expressRequest) {
-      const acceptLanguageHeader = expressRequest.headers['accept-language'];
-      const acceptLanguage = Array.isArray(acceptLanguageHeader)
+    if (isPlatformServer(platformId) && (expressRequest || netlifyRequest)) {
+      const acceptLanguageHeader = expressRequest?.headers['accept-language'];
+      const expressAcceptLanguage = Array.isArray(acceptLanguageHeader)
         ? acceptLanguageHeader.join(',')
         : acceptLanguageHeader;
+      const acceptLanguage =
+        expressAcceptLanguage ??
+        netlifyRequest?.headers.get('accept-language');
 
       if (acceptLanguage) {
         return acceptLanguage

--- a/apps/sanity-example/src/app/components/currency-amount.component.ts
+++ b/apps/sanity-example/src/app/components/currency-amount.component.ts
@@ -28,8 +28,7 @@ const getLanguagesFn = () => {
         ? acceptLanguageHeader.join(',')
         : acceptLanguageHeader;
       const acceptLanguage =
-        expressAcceptLanguage ??
-        netlifyRequest?.headers.get('accept-language');
+        expressAcceptLanguage ?? netlifyRequest?.headers.get('accept-language');
 
       if (acceptLanguage) {
         return acceptLanguage

--- a/apps/sanity-example/src/server.ts
+++ b/apps/sanity-example/src/server.ts
@@ -1,11 +1,21 @@
 import { APP_BASE_HREF } from '@angular/common';
 import { CommonEngine, isMainModule } from '@angular/ssr/node';
-import express, { type Request, type Response } from 'express';
+import { render } from '@netlify/angular-runtime/common-engine.js';
+import express, {
+  type Request as ExpressRequest,
+  type Response as ExpressResponse,
+} from 'express';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import bootstrap from './main.server';
 import { REQUEST, RESPONSE } from './server.tokens';
+
+const netlifyCommonEngine = new CommonEngine();
+
+export async function netlifyCommonEngineHandler(): Promise<globalThis.Response> {
+  return await render(netlifyCommonEngine);
+}
 
 export function app(): express.Express {
   const server = express();
@@ -24,7 +34,7 @@ export function app(): express.Express {
     }),
   );
 
-  server.get('**', (req: Request, res: Response, next) => {
+  server.get('**', (req: ExpressRequest, res: ExpressResponse, next) => {
     const { protocol, originalUrl, baseUrl, headers } = req;
 
     commonEngine

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  base = "apps/sanity-example"
+  command = "pnpm turbo run build --filter=sanity-example"
+  publish = "dist/sanity-example/browser"
+
+[[plugins]]
+  package = "@netlify/angular-runtime"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,5 +3,8 @@
   command = "pnpm turbo run build --filter=sanity-example"
   publish = "dist/sanity-example/browser"
 
+[build.environment]
+  NODE_VERSION = "22.22.3"
+
 [[plugins]]
   package = "@netlify/angular-runtime"

--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -8,6 +8,7 @@ Limitless Angular is a powerful collection of Angular libraries focused on Sanit
 
 ## Quick Links
 
+- 🚀 [Portable Text Live Demo](https://limitless-angular-sanity-example.netlify.app/)
 - 💻 [Example Project](/apps/sanity-example)
 - 📦 [NPM Package](https://www.npmjs.com/package/@limitless-angular/sanity)
 

--- a/packages/sanity/image-loader/README.md
+++ b/packages/sanity/image-loader/README.md
@@ -192,6 +192,7 @@ export const appConfig: ApplicationConfig = {
 
 ## Examples & Resources
 
+- [Live Demo](https://limitless-angular-sanity-example.netlify.app/)
 - [Example Source Code](https://github.com/limitless-angular/limitless-angular/tree/main/apps/sanity-example)
 - [Sanity Image URL Builder docs](https://www.sanity.io/docs/image-url)
 - [NgOptimizedImage docs](https://angular.io/api/common/NgOptimizedImage)

--- a/packages/sanity/portabletext/README.md
+++ b/packages/sanity/portabletext/README.md
@@ -7,7 +7,9 @@ Render [Portable Text](https://portabletext.org/) with Angular.
 
 ## Demo
 
-See the example project in the monorepo: [`apps/sanity-example`](/apps/sanity-example)
+Check out our live demo of the Sanity example here: [Limitless Angular Sanity Example](https://limitless-angular-sanity-example.netlify.app/)
+
+You can also see the example project in the monorepo: [`apps/sanity-example`](/apps/sanity-example)
 
 ## Table of contents
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,13 +250,16 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: ~19.0.4
-        version: 19.0.4(c58bde49f6d7797f7d61633891680f09)
+        version: 19.0.4(858c0fea5b2807a03def4be9721b7cc4)
       '@angular/cli':
         specifier: ~19.0.4
         version: 19.0.4(@types/node@22.19.20)(chokidar@4.0.1)
       '@angular/compiler-cli':
         specifier: ~19.0.3
         version: 19.0.3(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3)
+      '@netlify/angular-runtime':
+        specifier: 4.0.0
+        version: 4.0.0
       '@tailwindcss/typography':
         specifier: ^0.5.13
         version: 0.5.15(tailwindcss@3.4.16(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@22.19.20)(typescript@5.6.3)))
@@ -3449,6 +3452,18 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@netlify/angular-runtime@4.0.0':
+    resolution: {integrity: sha512-VrFrzw0MbLWLCG853dJM5gHDg2uRMBWuedEb1DfLDNyja/dQnmQTMPE2ke9QTbebFA01T0aynM0aeU7DyinPOQ==}
+    engines: {node: ^22.22.0 || ^24.13.1 || >=26.0.0}
+
+  '@netlify/edge-functions@3.0.8':
+    resolution: {integrity: sha512-ml1oCDsRTTRmZS2nUj8XRD1b6+foEiZT3lPk7qQ4nv/jnxylHJ20ooPzPDH+cJmGjXFrMeR14/91W1o6D2ftBg==}
+    engines: {node: '>=18.0.0'}
+
+  '@netlify/types@2.8.0':
+    resolution: {integrity: sha512-8/g0Pt6y6wXj5Ia5eeYLiXhRfWeqZXGXpGFeCiiQdUOem+FPtXdA4+YdGxqzWc7D0AvptKSO01KGeeVWHSu8Kg==}
+    engines: {node: ^18.14.0 || >=20}
 
   '@ngtools/webpack@19.0.4':
     resolution: {integrity: sha512-N3WCbQz5ipdAZoSWHNf81RLET6+isq35+GZu9u0StpFtJCpXAmRRAv4vdMUYL7DLOzRmvEgwww6Rd5AwGeLFSw==}
@@ -12779,13 +12794,13 @@ snapshots:
       - vite
       - webpack-cli
 
-  '@angular-devkit/build-angular@19.0.4(8c9a17d16580a0c206005aa4f0974c6c)':
+  '@angular-devkit/build-angular@19.0.4(858c0fea5b2807a03def4be9721b7cc4)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1900.4(chokidar@4.0.1)
       '@angular-devkit/build-webpack': 0.1900.4(chokidar@4.0.1)(webpack-dev-server@5.1.0(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)))(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
       '@angular-devkit/core': 19.0.4(chokidar@4.0.1)
-      '@angular/build': 19.0.4(546350c9cb52991c0b79fce3be92640f)
+      '@angular/build': 19.0.4(1f8472465ff9a46f3446651c2581c8c8)
       '@angular/compiler-cli': 19.0.3(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3)
       '@babel/core': 7.26.0
       '@babel/generator': 7.26.2
@@ -12798,7 +12813,7 @@ snapshots:
       '@babel/runtime': 7.26.0
       '@discoveryjs/json-ext': 0.6.3
       '@ngtools/webpack': 19.0.4(@angular/compiler-cli@19.0.3(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3))(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      '@vitejs/plugin-basic-ssl': 1.1.0(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.82.0)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))
+      '@vitejs/plugin-basic-ssl': 1.1.0(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.20(postcss@8.4.49)
       babel-loader: 9.2.1(@babel/core@7.26.0)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
@@ -12866,13 +12881,13 @@ snapshots:
       - vite
       - webpack-cli
 
-  '@angular-devkit/build-angular@19.0.4(c58bde49f6d7797f7d61633891680f09)':
+  '@angular-devkit/build-angular@19.0.4(8c9a17d16580a0c206005aa4f0974c6c)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1900.4(chokidar@4.0.1)
       '@angular-devkit/build-webpack': 0.1900.4(chokidar@4.0.1)(webpack-dev-server@5.1.0(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)))(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
       '@angular-devkit/core': 19.0.4(chokidar@4.0.1)
-      '@angular/build': 19.0.4(1f8472465ff9a46f3446651c2581c8c8)
+      '@angular/build': 19.0.4(546350c9cb52991c0b79fce3be92640f)
       '@angular/compiler-cli': 19.0.3(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3)
       '@babel/core': 7.26.0
       '@babel/generator': 7.26.2
@@ -16796,6 +16811,17 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@netlify/angular-runtime@4.0.0':
+    dependencies:
+      '@netlify/edge-functions': 3.0.8
+      semver: 7.8.2
+
+  '@netlify/edge-functions@3.0.8':
+    dependencies:
+      '@netlify/types': 2.8.0
+
+  '@netlify/types@2.8.0': {}
+
   '@ngtools/webpack@19.0.4(@angular/compiler-cli@19.0.3(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3))(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))':
     dependencies:
       '@angular/compiler-cli': 19.0.3(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3)
@@ -16829,7 +16855,7 @@ snapshots:
 
   '@npmcli/fs@4.0.0':
     dependencies:
-      semver: 7.6.3
+      semver: 7.8.2
 
   '@npmcli/git@6.0.1':
     dependencies:
@@ -24047,7 +24073,7 @@ snapshots:
       make-fetch-happen: 14.0.3
       nopt: 8.0.0
       proc-log: 5.0.0
-      semver: 7.6.3
+      semver: 7.8.2
       tar: 7.4.3
       which: 5.0.0
     transitivePeerDependencies:
@@ -24097,7 +24123,7 @@ snapshots:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.15.1
-      semver: 7.6.3
+      semver: 7.8.2
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@7.0.0:


### PR DESCRIPTION
## PR Checklist

Restores the Netlify deployment references that were removed during the Turborepo migration, while keeping outdated Netlify runtime v2 patching out of the current setup.

Closes #

## What is the new behavior?

- Restores the root Netlify config for the sanity example deployment.
- Installs and uses `@netlify/angular-runtime@4.0.0` for the sanity example SSR handler.
- Pins the Netlify deploy Node version to match the runtime engine requirement.
- Restores the Netlify request fallback used by the currency example when running under the Netlify edge SSR context.
- Restores the public Netlify live-demo links in the Sanity package READMEs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validated with:

- `volta run --node 22.22.3 --pnpm 11.5.2 pnpm install --frozen-lockfile`
- `volta run --node 22.22.3 --pnpm 11.5.2 pnpm turbo run build --filter=sanity-example`
- `volta run --node 22.22.3 --pnpm 11.5.2 pnpm turbo run lint --filter=sanity-example`
- Simulated `@netlify/angular-runtime` `onPreBuild`/`onBuild` hooks against the sanity example build output.

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
