### PR TITLE
fix: pin Volta runtime for setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     "release": "node tools/scripts/release.ts"
   },
   "packageManager": "pnpm@11.5.2",
+  "volta": {
+    "node": "22.22.3",
+    "pnpm": "11.5.2"
+  },
   "engines": {
     "node": ">=22.22.3",
     "pnpm": ">=11.5.2"


### PR DESCRIPTION
## PR Checklist

Fixes a local Codex worktree setup failure where the generated setup script ran `pnpm install --frozen-lockfile` under Volta's default Node `24.11.0`, which fails `@netlify/angular-runtime@4.0.0` engine checks.

Closes #

## What is the new behavior?

Adds a `volta` pin in the root `package.json` for Node `22.22.3` and pnpm `11.5.2`, matching the existing `.nvmrc`, `packageManager`, and engine requirements. This lets plain `pnpm install --frozen-lockfile` use the compatible Node version during local environment setup.

Validation:

- Reproduced the setup failure under Node `24.11.0`.
- Verified `nvm use && pnpm install --frozen-lockfile` succeeds.
- Verified plain `node -v` resolves to `v22.22.3` after the Volta pin.
- Ran the selected setup script commands manually; they completed successfully.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Ignored setup artifacts such as `node_modules`, copied `.env.local` files, and `.auth` were created locally while verifying the setup, but are not included in this PR.

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
