### PR TITLE
fix: pin pnpm engine node version

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,3 +14,4 @@ allowBuilds:
   msgpackr-extract: true
   nx: true
 engineStrict: true
+nodeVersion: 22.22.3


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

Setup can fail when `pnpm install --frozen-lockfile` is launched under Node `v24.11.0`, because `@netlify/angular-runtime@4.0.0` requires `^22.22.0 || ^24.13.1 || >=26.0.0` and this workspace has `engineStrict: true`.

## What is the new behavior?

<!-- Please describe the changes made in this PR -->

Adds `nodeVersion: 22.22.3` to `pnpm-workspace.yaml` so pnpm evaluates package engine compatibility against the same Node version already pinned by `.nvmrc` and Volta.

Validated with:

- `pnpm install --frozen-lockfile`
- full local setup script contents from the selected Codex environment
- full setup path with `PATH` forced to prefer Node `v24.11.0` and Homebrew pnpm
- `git diff --check`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This is a local-environment repair only. No dependencies or lockfile entries changed.

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

