### PR TITLE
docs(sanity): note portable text origin version

### DIFF
--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -204,7 +204,7 @@ We welcome contributions! Check our [Contributing Guide](CONTRIBUTING.md) for de
 
 ## Credits
 
-Adapted from [@portabletext/react](https://github.com/portabletext/react-portabletext) which provided the
+Adapted from [@portabletext/react v3.1.0](https://github.com/portabletext/react-portabletext/blob/main/CHANGELOG.md#310-2024-05-28) which provided the
 vast majority of node rendering logic.
 
 ## License

--- a/packages/sanity/portabletext/README.md
+++ b/packages/sanity/portabletext/README.md
@@ -5,6 +5,8 @@
 
 Render [Portable Text](https://portabletext.org/) with Angular.
 
+Based on [@portabletext/react v3.1.0](https://github.com/portabletext/react-portabletext/blob/main/CHANGELOG.md#310-2024-05-28).
+
 ## Demo
 
 Check out our live demo of the Sanity example here: [Limitless Angular Sanity Example](https://limitless-angular-sanity-example.netlify.app/)


### PR DESCRIPTION
## PR Checklist

Closes #

## What is the new behavior?

Documents that `@limitless-angular/sanity/portabletext` is based on `@portabletext/react v3.1.0`, including the upstream changelog link and date.

Updates the root Sanity README credit to mention the same upstream version.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

README-only change. Validation: reviewed the staged diff; no tests were run.

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
