### PR TITLE
build: replace angular devkit builder package

### DIFF
--- a/apps/analog-sanity-blog-example/package.json
+++ b/apps/analog-sanity-blog-example/package.json
@@ -32,7 +32,6 @@
   "devDependencies": {
     "@analogjs/content": "2.6.0",
     "@analogjs/platform": "2.6.0",
-    "@angular-devkit/build-angular": "~19.0.4",
     "@angular/build": "~19.0.4",
     "@angular/cli": "~19.0.4",
     "@angular/compiler-cli": "~19.0.3",

--- a/apps/sanity-example/angular.json
+++ b/apps/sanity-example/angular.json
@@ -10,7 +10,7 @@
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular/build:application",
           "options": {
             "outputPath": "dist/sanity-example",
             "index": "src/index.html",
@@ -65,7 +65,7 @@
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
+          "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
               "buildTarget": "sanity-example:build:production"
@@ -77,7 +77,7 @@
           "defaultConfiguration": "development"
         },
         "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n",
+          "builder": "@angular/build:extract-i18n",
           "options": {
             "buildTarget": "sanity-example:build"
           }

--- a/apps/sanity-example/package.json
+++ b/apps/sanity-example/package.json
@@ -28,7 +28,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~19.0.4",
+    "@angular/build": "~19.0.4",
     "@angular/cli": "~19.0.4",
     "@angular/compiler-cli": "~19.0.3",
     "@netlify/angular-runtime": "4.0.0",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -54,7 +54,6 @@
     "@analogjs/vite-plugin-angular": "^2.6.0",
     "@analogjs/vitest-angular": "^2.6.0",
     "@angular-devkit/architect": "~0.1900.4",
-    "@angular-devkit/build-angular": "~19.0.4",
     "@angular/build": "~19.0.4",
     "@angular/common": "~19.0.3",
     "@angular/compiler": "~19.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,13 +123,10 @@ importers:
         version: 2.6.0(bb7791bf9abafc798791396475b713da)
       '@analogjs/platform':
         specifier: 2.6.0
-        version: 2.6.0(ef2bdecbfe25bba6a851f7deb4f3dbfd)
-      '@angular-devkit/build-angular':
-        specifier: ~19.0.4
-        version: 19.0.4(687032b4eee37ef4d96c11dc2ab0877c)
+        version: 2.6.0(7278761ba98590a39eda2ac41ab56ca4)
       '@angular/build':
         specifier: ~19.0.4
-        version: 19.0.4(2bbb89f59df25a6c60d5af07ba76e3fc)
+        version: 19.0.4(82f8b91c36274bb7d4d24bf0d4ba4149)
       '@angular/cli':
         specifier: ~19.0.4
         version: 19.0.4(@types/node@22.19.20)(chokidar@4.0.1)
@@ -183,10 +180,10 @@ importers:
         version: 8.18.0(eslint@9.16.0(jiti@2.7.0))(typescript@5.6.3)
       vite:
         specifier: ^8.0.16
-        version: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)
+        version: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)
       vite-plugin-webfont-dl:
         specifier: ^3.12.0
-        version: 3.12.0(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))
+        version: 3.12.0(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))
 
   apps/sanity-example:
     dependencies:
@@ -248,9 +245,9 @@ importers:
         specifier: ^2.3.0
         version: 2.8.1
     devDependencies:
-      '@angular-devkit/build-angular':
+      '@angular/build':
         specifier: ~19.0.4
-        version: 19.0.4(858c0fea5b2807a03def4be9721b7cc4)
+        version: 19.0.4(eee1a75a6a976d6e8d30f760b5564c9d)
       '@angular/cli':
         specifier: ~19.0.4
         version: 19.0.4(@types/node@22.19.20)(chokidar@4.0.1)
@@ -364,9 +361,6 @@ importers:
       '@angular-devkit/architect':
         specifier: ~0.1900.4
         version: 0.1900.4(chokidar@4.0.1)
-      '@angular-devkit/build-angular':
-        specifier: ~19.0.4
-        version: 19.0.4(8c9a17d16580a0c206005aa4f0974c6c)
       '@angular/build':
         specifier: ~19.0.4
         version: 19.0.4(82f8b91c36274bb7d4d24bf0d4ba4149)
@@ -2812,10 +2806,6 @@ packages:
 
   '@istanbuljs/load-nyc-config@1.1.0':
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
-    engines: {node: '>=8'}
-
-  '@istanbuljs/schema@0.1.3':
-    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
   '@istanbuljs/schema@0.1.6':
@@ -5762,10 +5752,6 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
-  ansi-regex@6.1.0:
-    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
-    engines: {node: '>=12'}
-
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
@@ -5781,10 +5767,6 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
-
-  ansi-styles@6.2.1:
-    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
-    engines: {node: '>=12'}
 
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
@@ -6621,9 +6603,6 @@ packages:
       lightningcss:
         optional: true
 
-  css-select@5.1.0:
-    resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
-
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
@@ -6637,10 +6616,6 @@ packages:
   css-tree@2.3.1:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
-
-  css-what@6.1.0:
-    resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
-    engines: {node: '>= 6'}
 
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
@@ -6916,10 +6891,6 @@ packages:
     engines: {node: '>=0.10'}
     hasBin: true
 
-  detect-libc@2.0.3:
-    resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
-    engines: {node: '>=8'}
-
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -6985,9 +6956,6 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
-
-  domutils@3.1.0:
-    resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -11172,10 +11140,6 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
-  strip-ansi@7.1.0:
-    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
-    engines: {node: '>=12'}
-
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
@@ -11388,11 +11352,6 @@ packages:
 
   terser@5.36.0:
     resolution: {integrity: sha512-IYV9eNMuFAV4THUspIRXkLakHnV6XO7FEdtKjf/mDyrnqUg9LnlOn6/RwRvM9SZjR4GUq8Nk8zj67FzVARr74w==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  terser@5.37.0:
-    resolution: {integrity: sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -12383,10 +12342,6 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
-  wrap-ansi@9.0.0:
-    resolution: {integrity: sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==}
-    engines: {node: '>=18'}
-
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
@@ -12580,20 +12535,20 @@ snapshots:
     optionalDependencies:
       '@nx/devkit': 20.2.2(nx@20.2.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23)))
 
-  '@analogjs/platform@2.6.0(ef2bdecbfe25bba6a851f7deb4f3dbfd)':
+  '@analogjs/platform@2.6.0(7278761ba98590a39eda2ac41ab56ca4)':
     dependencies:
-      '@analogjs/vite-plugin-angular': 2.6.0(@angular-devkit/build-angular@19.0.4(687032b4eee37ef4d96c11dc2ab0877c))(@angular/build@19.0.4(2bbb89f59df25a6c60d5af07ba76e3fc))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))
+      '@analogjs/vite-plugin-angular': 2.6.0(@angular-devkit/build-angular@19.0.4(9eb2bc13f78f652cd1bf9ab56ac028e9))(@angular/build@19.0.4(82f8b91c36274bb7d4d24bf0d4ba4149))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))
       '@analogjs/vite-plugin-nitro': 2.6.0(encoding@0.1.13)(oxc-parser@0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.3)
       marked: 15.0.12
       marked-gfm-heading-id: 4.1.4(marked@15.0.12)
       marked-mangle: 1.1.13(marked@15.0.12)
       nitropack: 2.13.4(encoding@0.1.13)(oxc-parser@0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.0.3)
-      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)
-      vitefu: 1.1.3(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))
+      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)
+      vitefu: 1.1.3(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))
     optionalDependencies:
-      '@nx/angular': 20.2.2(@angular-devkit/build-angular@19.0.4(687032b4eee37ef4d96c11dc2ab0877c))(@angular-devkit/core@19.0.4(chokidar@4.0.1))(@angular-devkit/schematics@19.0.4(chokidar@4.0.1))(@babel/traverse@7.26.4)(@rspack/core@1.1.6(@swc/helpers@0.5.23))(@schematics/angular@19.0.4(chokidar@4.0.1))(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@types/node@22.19.20)(@zkochan/js-yaml@0.0.7)(esbuild@0.28.0)(eslint@9.16.0(jiti@2.7.0))(lightningcss@1.32.0)(nx@20.2.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23)))(postcss@8.4.49)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rxjs@7.8.1)(typescript@5.6.3)
+      '@nx/angular': 20.2.2(@angular-devkit/build-angular@19.0.4(9eb2bc13f78f652cd1bf9ab56ac028e9))(@angular-devkit/core@19.0.4(chokidar@4.0.1))(@angular-devkit/schematics@19.0.4(chokidar@4.0.1))(@babel/traverse@7.26.4)(@rspack/core@1.1.6(@swc/helpers@0.5.23))(@schematics/angular@19.0.4(chokidar@4.0.1))(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@types/node@22.19.20)(@zkochan/js-yaml@0.0.7)(esbuild@0.28.0)(eslint@9.16.0(jiti@2.7.0))(lightningcss@1.32.0)(nx@20.2.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23)))(postcss@8.4.49)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rxjs@7.8.1)(typescript@5.6.3)
       '@nx/devkit': 20.2.2(nx@20.2.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23)))
-      '@nx/vite': 20.2.2(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@22.19.20)(nx@20.2.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23)))(typescript@5.6.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))(vitest@4.1.8(@types/node@22.19.20)(jsdom@22.1.0)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)))
+      '@nx/vite': 20.2.2(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@22.19.20)(nx@20.2.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23)))(typescript@5.6.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))(vitest@4.1.8(@types/node@22.19.20)(jsdom@22.1.0)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)))
       marked-highlight: 2.2.4(marked@15.0.12)
       prismjs: 1.29.0
     transitivePeerDependencies:
@@ -12637,21 +12592,6 @@ snapshots:
       '@angular/router': 19.0.3(@angular/common@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.0.3(@angular/animations@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(rxjs@7.8.1)
       tslib: 2.8.1
 
-  '@analogjs/vite-plugin-angular@2.6.0(@angular-devkit/build-angular@19.0.4(687032b4eee37ef4d96c11dc2ab0877c))(@angular/build@19.0.4(2bbb89f59df25a6c60d5af07ba76e3fc))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))':
-    dependencies:
-      magic-string: 0.30.21
-      obug: 2.1.2
-      oxc-parser: 0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      tinyglobby: 0.2.17
-      ts-morph: 21.0.1
-    optionalDependencies:
-      '@angular-devkit/build-angular': 19.0.4(687032b4eee37ef4d96c11dc2ab0877c)
-      '@angular/build': 19.0.4(2bbb89f59df25a6c60d5af07ba76e3fc)
-      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
   '@analogjs/vite-plugin-angular@2.6.0(@angular-devkit/build-angular@19.0.4(8c9a17d16580a0c206005aa4f0974c6c))(@angular/build@19.0.4(82f8b91c36274bb7d4d24bf0d4ba4149))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.82.0)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))':
     dependencies:
       magic-string: 0.30.21
@@ -12663,6 +12603,21 @@ snapshots:
       '@angular-devkit/build-angular': 19.0.4(8c9a17d16580a0c206005aa4f0974c6c)
       '@angular/build': 19.0.4(82f8b91c36274bb7d4d24bf0d4ba4149)
       vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.82.0)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  '@analogjs/vite-plugin-angular@2.6.0(@angular-devkit/build-angular@19.0.4(9eb2bc13f78f652cd1bf9ab56ac028e9))(@angular/build@19.0.4(82f8b91c36274bb7d4d24bf0d4ba4149))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))':
+    dependencies:
+      magic-string: 0.30.21
+      obug: 2.1.2
+      oxc-parser: 0.121.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      tinyglobby: 0.2.17
+      ts-morph: 21.0.1
+    optionalDependencies:
+      '@angular-devkit/build-angular': 19.0.4(9eb2bc13f78f652cd1bf9ab56ac028e9)
+      '@angular/build': 19.0.4(82f8b91c36274bb7d4d24bf0d4ba4149)
+      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -12720,180 +12675,6 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@19.0.4(687032b4eee37ef4d96c11dc2ab0877c)':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.1900.4(chokidar@4.0.1)
-      '@angular-devkit/build-webpack': 0.1900.4(chokidar@4.0.1)(webpack-dev-server@5.1.0(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)))(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      '@angular-devkit/core': 19.0.4(chokidar@4.0.1)
-      '@angular/build': 19.0.4(546350c9cb52991c0b79fce3be92640f)
-      '@angular/compiler-cli': 19.0.3(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3)
-      '@babel/core': 7.26.0
-      '@babel/generator': 7.26.2
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/plugin-transform-async-generator-functions': 7.25.9(@babel/core@7.26.0)
-      '@babel/plugin-transform-async-to-generator': 7.25.9(@babel/core@7.26.0)
-      '@babel/plugin-transform-runtime': 7.25.9(@babel/core@7.26.0)
-      '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
-      '@babel/runtime': 7.26.0
-      '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 19.0.4(@angular/compiler-cli@19.0.3(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3))(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      '@vitejs/plugin-basic-ssl': 1.1.0(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))
-      ansi-colors: 4.1.3
-      autoprefixer: 10.4.20(postcss@8.4.49)
-      babel-loader: 9.2.1(@babel/core@7.26.0)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      browserslist: 4.24.2
-      copy-webpack-plugin: 12.0.2(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      css-loader: 7.1.2(@rspack/core@1.1.6(@swc/helpers@0.5.23))(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      esbuild-wasm: 0.24.0
-      fast-glob: 3.3.2
-      http-proxy-middleware: 3.0.3
-      istanbul-lib-instrument: 6.0.3
-      jsonc-parser: 3.3.1
-      karma-source-map-support: 1.4.0
-      less: 4.2.0
-      less-loader: 12.2.0(@rspack/core@1.1.6(@swc/helpers@0.5.23))(less@4.2.0)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      license-webpack-plugin: 4.0.2(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.2(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      open: 10.1.0
-      ora: 5.4.1
-      picomatch: 4.0.2
-      piscina: 4.7.0
-      postcss: 8.4.49
-      postcss-loader: 8.1.1(@rspack/core@1.1.6(@swc/helpers@0.5.23))(postcss@8.4.49)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      resolve-url-loader: 5.0.0
-      rxjs: 7.8.1
-      sass: 1.80.7
-      sass-loader: 16.0.3(@rspack/core@1.1.6(@swc/helpers@0.5.23))(sass@1.80.7)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      semver: 7.6.3
-      source-map-loader: 5.0.0(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      source-map-support: 0.5.21
-      terser: 5.36.0
-      tree-kill: 1.2.2
-      tslib: 2.8.1
-      typescript: 5.6.3
-      webpack: 5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)
-      webpack-dev-middleware: 7.4.2(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      webpack-dev-server: 5.1.0(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-    optionalDependencies:
-      '@angular/platform-server': 19.0.3(@angular/animations@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.0.3(@angular/animations@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))
-      '@angular/ssr': 19.0.4(79a92b4132a097a06ed59745efadfdd6)
-      esbuild: 0.24.0
-      jest: 29.7.0(@types/node@22.19.20)(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@22.19.20)(typescript@5.6.3))
-      jest-environment-jsdom: 29.7.0
-      ng-packagr: 19.0.1(@angular/compiler-cli@19.0.3(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3))(tailwindcss@3.4.16(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@22.19.20)(typescript@5.6.3)))(tslib@2.8.1)(typescript@5.6.3)
-      tailwindcss: 3.4.16(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@22.19.20)(typescript@5.6.3))
-    transitivePeerDependencies:
-      - '@angular/compiler'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@types/node'
-      - bufferutil
-      - chokidar
-      - debug
-      - html-webpack-plugin
-      - lightningcss
-      - node-sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - uglify-js
-      - utf-8-validate
-      - vite
-      - webpack-cli
-
-  '@angular-devkit/build-angular@19.0.4(858c0fea5b2807a03def4be9721b7cc4)':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.1900.4(chokidar@4.0.1)
-      '@angular-devkit/build-webpack': 0.1900.4(chokidar@4.0.1)(webpack-dev-server@5.1.0(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)))(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      '@angular-devkit/core': 19.0.4(chokidar@4.0.1)
-      '@angular/build': 19.0.4(1f8472465ff9a46f3446651c2581c8c8)
-      '@angular/compiler-cli': 19.0.3(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3)
-      '@babel/core': 7.26.0
-      '@babel/generator': 7.26.2
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/plugin-transform-async-generator-functions': 7.25.9(@babel/core@7.26.0)
-      '@babel/plugin-transform-async-to-generator': 7.25.9(@babel/core@7.26.0)
-      '@babel/plugin-transform-runtime': 7.25.9(@babel/core@7.26.0)
-      '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
-      '@babel/runtime': 7.26.0
-      '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 19.0.4(@angular/compiler-cli@19.0.3(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3))(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      '@vitejs/plugin-basic-ssl': 1.1.0(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))
-      ansi-colors: 4.1.3
-      autoprefixer: 10.4.20(postcss@8.4.49)
-      babel-loader: 9.2.1(@babel/core@7.26.0)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      browserslist: 4.24.2
-      copy-webpack-plugin: 12.0.2(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      css-loader: 7.1.2(@rspack/core@1.1.6(@swc/helpers@0.5.23))(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      esbuild-wasm: 0.24.0
-      fast-glob: 3.3.2
-      http-proxy-middleware: 3.0.3
-      istanbul-lib-instrument: 6.0.3
-      jsonc-parser: 3.3.1
-      karma-source-map-support: 1.4.0
-      less: 4.2.0
-      less-loader: 12.2.0(@rspack/core@1.1.6(@swc/helpers@0.5.23))(less@4.2.0)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      license-webpack-plugin: 4.0.2(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.2(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      open: 10.1.0
-      ora: 5.4.1
-      picomatch: 4.0.2
-      piscina: 4.7.0
-      postcss: 8.4.49
-      postcss-loader: 8.1.1(@rspack/core@1.1.6(@swc/helpers@0.5.23))(postcss@8.4.49)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      resolve-url-loader: 5.0.0
-      rxjs: 7.8.1
-      sass: 1.80.7
-      sass-loader: 16.0.3(@rspack/core@1.1.6(@swc/helpers@0.5.23))(sass@1.80.7)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      semver: 7.6.3
-      source-map-loader: 5.0.0(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      source-map-support: 0.5.21
-      terser: 5.36.0
-      tree-kill: 1.2.2
-      tslib: 2.8.1
-      typescript: 5.6.3
-      webpack: 5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)
-      webpack-dev-middleware: 7.4.2(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      webpack-dev-server: 5.1.0(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-    optionalDependencies:
-      '@angular/platform-server': 19.0.3(@angular/animations@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.0.3(@angular/animations@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))
-      '@angular/ssr': 19.0.4(79a92b4132a097a06ed59745efadfdd6)
-      esbuild: 0.24.0
-      jest: 29.7.0(@types/node@22.19.20)(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@22.19.20)(typescript@5.6.3))
-      jest-environment-jsdom: 29.7.0
-      ng-packagr: 19.0.1(@angular/compiler-cli@19.0.3(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3))(tailwindcss@3.4.16(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@22.19.20)(typescript@5.6.3)))(tslib@2.8.1)(typescript@5.6.3)
-      tailwindcss: 3.4.16(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@22.19.20)(typescript@5.6.3))
-    transitivePeerDependencies:
-      - '@angular/compiler'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@types/node'
-      - bufferutil
-      - chokidar
-      - debug
-      - html-webpack-plugin
-      - lightningcss
-      - node-sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - uglify-js
-      - utf-8-validate
-      - vite
-      - webpack-cli
-
   '@angular-devkit/build-angular@19.0.4(8c9a17d16580a0c206005aa4f0974c6c)':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -12917,7 +12698,7 @@ snapshots:
       ansi-colors: 4.1.3
       autoprefixer: 10.4.20(postcss@8.4.49)
       babel-loader: 9.2.1(@babel/core@7.26.0)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      browserslist: 4.24.2
+      browserslist: 4.28.2
       copy-webpack-plugin: 12.0.2(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
       css-loader: 7.1.2(@rspack/core@1.1.6(@swc/helpers@0.5.23))(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
       esbuild-wasm: 0.24.0
@@ -12980,6 +12761,95 @@ snapshots:
       - utf-8-validate
       - vite
       - webpack-cli
+    optional: true
+
+  '@angular-devkit/build-angular@19.0.4(9eb2bc13f78f652cd1bf9ab56ac028e9)':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@angular-devkit/architect': 0.1900.4(chokidar@4.0.1)
+      '@angular-devkit/build-webpack': 0.1900.4(chokidar@4.0.1)(webpack-dev-server@5.1.0(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)))(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
+      '@angular-devkit/core': 19.0.4(chokidar@4.0.1)
+      '@angular/build': 19.0.4(546350c9cb52991c0b79fce3be92640f)
+      '@angular/compiler-cli': 19.0.3(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3)
+      '@babel/core': 7.26.0
+      '@babel/generator': 7.26.2
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-split-export-declaration': 7.24.7
+      '@babel/plugin-transform-async-generator-functions': 7.25.9(@babel/core@7.26.0)
+      '@babel/plugin-transform-async-to-generator': 7.25.9(@babel/core@7.26.0)
+      '@babel/plugin-transform-runtime': 7.25.9(@babel/core@7.26.0)
+      '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
+      '@babel/runtime': 7.26.0
+      '@discoveryjs/json-ext': 0.6.3
+      '@ngtools/webpack': 19.0.4(@angular/compiler-cli@19.0.3(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3))(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
+      '@vitejs/plugin-basic-ssl': 1.1.0(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))
+      ansi-colors: 4.1.3
+      autoprefixer: 10.4.20(postcss@8.4.49)
+      babel-loader: 9.2.1(@babel/core@7.26.0)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
+      browserslist: 4.28.2
+      copy-webpack-plugin: 12.0.2(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
+      css-loader: 7.1.2(@rspack/core@1.1.6(@swc/helpers@0.5.23))(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
+      esbuild-wasm: 0.24.0
+      fast-glob: 3.3.2
+      http-proxy-middleware: 3.0.3
+      istanbul-lib-instrument: 6.0.3
+      jsonc-parser: 3.3.1
+      karma-source-map-support: 1.4.0
+      less: 4.2.0
+      less-loader: 12.2.0(@rspack/core@1.1.6(@swc/helpers@0.5.23))(less@4.2.0)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
+      license-webpack-plugin: 4.0.2(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
+      loader-utils: 3.3.1
+      mini-css-extract-plugin: 2.9.2(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
+      open: 10.1.0
+      ora: 5.4.1
+      picomatch: 4.0.2
+      piscina: 4.7.0
+      postcss: 8.4.49
+      postcss-loader: 8.1.1(@rspack/core@1.1.6(@swc/helpers@0.5.23))(postcss@8.4.49)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
+      resolve-url-loader: 5.0.0
+      rxjs: 7.8.1
+      sass: 1.80.7
+      sass-loader: 16.0.3(@rspack/core@1.1.6(@swc/helpers@0.5.23))(sass@1.80.7)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
+      semver: 7.6.3
+      source-map-loader: 5.0.0(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
+      source-map-support: 0.5.21
+      terser: 5.36.0
+      tree-kill: 1.2.2
+      tslib: 2.8.1
+      typescript: 5.6.3
+      webpack: 5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)
+      webpack-dev-middleware: 7.4.2(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
+      webpack-dev-server: 5.1.0(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
+      webpack-merge: 6.0.1
+      webpack-subresource-integrity: 5.1.0(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
+    optionalDependencies:
+      '@angular/platform-server': 19.0.3(@angular/animations@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.0.3(@angular/animations@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))
+      '@angular/ssr': 19.0.4(79a92b4132a097a06ed59745efadfdd6)
+      esbuild: 0.24.0
+      jest: 29.7.0(@types/node@22.19.20)(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@22.19.20)(typescript@5.6.3))
+      jest-environment-jsdom: 29.7.0
+      ng-packagr: 19.0.1(@angular/compiler-cli@19.0.3(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3))(tailwindcss@3.4.16(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@22.19.20)(typescript@5.6.3)))(tslib@2.8.1)(typescript@5.6.3)
+      tailwindcss: 3.4.16(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@22.19.20)(typescript@5.6.3))
+    transitivePeerDependencies:
+      - '@angular/compiler'
+      - '@rspack/core'
+      - '@swc/core'
+      - '@types/node'
+      - bufferutil
+      - chokidar
+      - debug
+      - html-webpack-plugin
+      - lightningcss
+      - node-sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - uglify-js
+      - utf-8-validate
+      - vite
+      - webpack-cli
+    optional: true
 
   '@angular-devkit/build-webpack@0.1900.4(chokidar@4.0.1)(webpack-dev-server@5.1.0(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)))(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))':
     dependencies:
@@ -12989,6 +12859,7 @@ snapshots:
       webpack-dev-server: 5.1.0(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
     transitivePeerDependencies:
       - chokidar
+    optional: true
 
   '@angular-devkit/core@19.0.4(chokidar@4.0.1)':
     dependencies:
@@ -13076,100 +12947,6 @@ snapshots:
       '@angular/core': 19.0.3(rxjs@7.8.1)(zone.js@0.15.0)
       tslib: 2.8.1
 
-  '@angular/build@19.0.4(1f8472465ff9a46f3446651c2581c8c8)':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.1900.4(chokidar@4.0.1)
-      '@angular/compiler': 19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))
-      '@angular/compiler-cli': 19.0.3(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3)
-      '@babel/core': 7.26.0
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.26.0)
-      '@inquirer/confirm': 5.0.2(@types/node@22.19.20)
-      '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.4.11(@types/node@22.19.20)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.36.0))
-      beasties: 0.1.0
-      browserslist: 4.24.2
-      esbuild: 0.24.0
-      fast-glob: 3.3.2
-      https-proxy-agent: 7.0.5
-      istanbul-lib-instrument: 6.0.3
-      listr2: 8.2.5
-      magic-string: 0.30.12
-      mrmime: 2.0.0
-      parse5-html-rewriting-stream: 7.0.0
-      picomatch: 4.0.2
-      piscina: 4.7.0
-      rollup: 4.26.0
-      sass: 1.80.7
-      semver: 7.6.3
-      typescript: 5.6.3
-      vite: 5.4.11(@types/node@22.19.20)(less@4.2.0)(lightningcss@1.32.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.36.0)
-      watchpack: 2.4.2
-    optionalDependencies:
-      '@angular/platform-server': 19.0.3(@angular/animations@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.0.3(@angular/animations@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))
-      '@angular/ssr': 19.0.4(79a92b4132a097a06ed59745efadfdd6)
-      less: 4.2.0
-      lmdb: 3.1.5
-      postcss: 8.4.49
-      tailwindcss: 3.4.16(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@22.19.20)(typescript@5.6.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - chokidar
-      - lightningcss
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  '@angular/build@19.0.4(2bbb89f59df25a6c60d5af07ba76e3fc)':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.1900.4(chokidar@4.0.1)
-      '@angular/compiler': 19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))
-      '@angular/compiler-cli': 19.0.3(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3)
-      '@babel/core': 7.26.0
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.26.0)
-      '@inquirer/confirm': 5.0.2(@types/node@22.19.20)
-      '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.4.11(@types/node@22.19.20)(less@4.2.0)(lightningcss@1.32.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0))
-      beasties: 0.1.0
-      browserslist: 4.24.2
-      esbuild: 0.24.0
-      fast-glob: 3.3.2
-      https-proxy-agent: 7.0.5
-      istanbul-lib-instrument: 6.0.3
-      listr2: 8.2.5
-      magic-string: 0.30.12
-      mrmime: 2.0.0
-      parse5-html-rewriting-stream: 7.0.0
-      picomatch: 4.0.2
-      piscina: 4.7.0
-      rollup: 4.26.0
-      sass: 1.80.7
-      semver: 7.6.3
-      typescript: 5.6.3
-      vite: 5.4.11(@types/node@22.19.20)(less@4.2.0)(lightningcss@1.32.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)
-      watchpack: 2.4.2
-    optionalDependencies:
-      '@angular/platform-server': 19.0.3(@angular/animations@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.0.3(@angular/animations@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))
-      '@angular/ssr': 19.0.4(79a92b4132a097a06ed59745efadfdd6)
-      less: 4.2.0
-      lmdb: 3.1.5
-      postcss: 8.4.49
-      tailwindcss: 3.4.16(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@22.19.20)(typescript@5.6.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - chokidar
-      - lightningcss
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   '@angular/build@19.0.4(546350c9cb52991c0b79fce3be92640f)':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -13181,9 +12958,9 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.24.7
       '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.26.0)
       '@inquirer/confirm': 5.0.2(@types/node@22.19.20)
-      '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.4.11(@types/node@22.19.20)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.36.0))
+      '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.4.11(@types/node@22.19.20)(less@4.2.0)(lightningcss@1.32.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.36.0))
       beasties: 0.1.0
-      browserslist: 4.24.2
+      browserslist: 4.28.2
       esbuild: 0.24.0
       fast-glob: 3.3.2
       https-proxy-agent: 7.0.5
@@ -13216,6 +12993,7 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+    optional: true
 
   '@angular/build@19.0.4(82f8b91c36274bb7d4d24bf0d4ba4149)':
     dependencies:
@@ -13230,7 +13008,7 @@ snapshots:
       '@inquirer/confirm': 5.0.2(@types/node@22.19.20)
       '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.4.11(@types/node@22.19.20)(less@4.2.1)(lightningcss@1.32.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0))
       beasties: 0.1.0
-      browserslist: 4.24.2
+      browserslist: 4.28.2
       esbuild: 0.24.0
       fast-glob: 3.3.2
       https-proxy-agent: 7.0.5
@@ -13253,6 +13031,53 @@ snapshots:
       less: 4.2.1
       lmdb: 3.1.5
       postcss: 8.4.49
+      tailwindcss: 3.4.16(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@22.19.20)(typescript@5.6.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - chokidar
+      - lightningcss
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  '@angular/build@19.0.4(eee1a75a6a976d6e8d30f760b5564c9d)':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@angular-devkit/architect': 0.1900.4(chokidar@4.0.1)
+      '@angular/compiler': 19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))
+      '@angular/compiler-cli': 19.0.3(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3)
+      '@babel/core': 7.26.0
+      '@babel/helper-annotate-as-pure': 7.25.9
+      '@babel/helper-split-export-declaration': 7.24.7
+      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.26.0)
+      '@inquirer/confirm': 5.0.2(@types/node@22.19.20)
+      '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.4.11(@types/node@22.19.20)(less@4.2.1)(lightningcss@1.32.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0))
+      beasties: 0.1.0
+      browserslist: 4.28.2
+      esbuild: 0.24.0
+      fast-glob: 3.3.2
+      https-proxy-agent: 7.0.5
+      istanbul-lib-instrument: 6.0.3
+      listr2: 8.2.5
+      magic-string: 0.30.12
+      mrmime: 2.0.0
+      parse5-html-rewriting-stream: 7.0.0
+      picomatch: 4.0.2
+      piscina: 4.7.0
+      rollup: 4.26.0
+      sass: 1.80.7
+      semver: 7.6.3
+      typescript: 5.6.3
+      vite: 5.4.11(@types/node@22.19.20)(less@4.2.1)(lightningcss@1.32.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)
+      watchpack: 2.4.2
+    optionalDependencies:
+      '@angular/platform-server': 19.0.3(@angular/animations@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.0.3(@angular/animations@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))
+      '@angular/ssr': 19.0.4(79a92b4132a097a06ed59745efadfdd6)
+      less: 4.2.1
+      lmdb: 3.1.5
+      postcss: 8.5.15
       tailwindcss: 3.4.16(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@22.19.20)(typescript@5.6.3))
     transitivePeerDependencies:
       - '@types/node'
@@ -13432,7 +13257,8 @@ snapshots:
       '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.0.2
+      jsesc: 3.1.0
+    optional: true
 
   '@babel/generator@7.29.7':
     dependencies:
@@ -13440,7 +13266,7 @@ snapshots:
       '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
-      jsesc: 3.0.2
+      jsesc: 3.1.0
 
   '@babel/helper-annotate-as-pure@7.25.9':
     dependencies:
@@ -13454,7 +13280,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.24.2
+      browserslist: 4.28.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -13470,6 +13296,7 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/helper-create-class-features-plugin@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -13504,6 +13331,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.29.7
       regexpu-core: 6.2.0
       semver: 6.3.1
+    optional: true
 
   '@babel/helper-create-regexp-features-plugin@7.26.3(@babel/core@7.29.7)':
     dependencies:
@@ -13530,6 +13358,7 @@ snapshots:
       resolve: 1.22.8
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/helper-define-polyfill-provider@0.6.3(@babel/core@7.29.7)':
     dependencies:
@@ -13616,6 +13445,7 @@ snapshots:
       '@babel/traverse': 7.26.4
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/helper-remap-async-to-generator@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -13644,6 +13474,7 @@ snapshots:
       '@babel/traverse': 7.26.4
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/helper-replace-supers@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -13722,6 +13553,7 @@ snapshots:
       '@babel/traverse': 7.26.4
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -13744,6 +13576,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -13760,6 +13593,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -13789,6 +13623,7 @@ snapshots:
       '@babel/plugin-transform-optional-chaining': 7.25.9(@babel/core@7.26.0)
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -13816,6 +13651,7 @@ snapshots:
       '@babel/traverse': 7.26.4
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -13847,6 +13683,7 @@ snapshots:
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
+    optional: true
 
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)':
     dependencies:
@@ -13886,6 +13723,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-syntax-import-assertions@7.26.0(@babel/core@7.29.7)':
     dependencies:
@@ -13903,16 +13741,16 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.29.7)':
+  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.26.0)':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-    optional: true
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7)':
     dependencies:
@@ -14000,6 +13838,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.7)':
     dependencies:
@@ -14011,6 +13850,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-arrow-functions@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14031,6 +13871,7 @@ snapshots:
       '@babel/traverse': 7.26.4
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-transform-async-generator-functions@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14059,6 +13900,7 @@ snapshots:
       '@babel/helper-remap-async-to-generator': 7.25.9(@babel/core@7.26.0)
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-transform-async-to-generator@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14083,6 +13925,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-block-scoped-functions@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14099,6 +13942,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-block-scoping@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14118,6 +13962,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-transform-class-properties@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14143,6 +13988,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-transform-class-static-block@7.26.0(@babel/core@7.29.7)':
     dependencies:
@@ -14172,6 +14018,7 @@ snapshots:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-transform-classes@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14203,6 +14050,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/template': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-computed-properties@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14221,6 +14069,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-destructuring@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14241,6 +14090,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-dotall-regex@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14259,6 +14109,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-duplicate-keys@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14276,6 +14127,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14294,6 +14146,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-dynamic-import@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14319,6 +14172,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-exponentiation-operator@7.26.3(@babel/core@7.29.7)':
     dependencies:
@@ -14335,6 +14189,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-export-namespace-from@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14354,6 +14209,7 @@ snapshots:
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-transform-for-of@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14380,6 +14236,7 @@ snapshots:
       '@babel/traverse': 7.26.4
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-transform-function-name@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14404,6 +14261,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-json-strings@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14420,6 +14278,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-literals@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14436,6 +14295,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-logical-assignment-operators@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14452,6 +14312,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-member-expression-literals@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14471,6 +14332,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-transform-modules-amd@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14496,6 +14358,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-transform-modules-commonjs@7.26.3(@babel/core@7.29.7)':
     dependencies:
@@ -14523,6 +14386,7 @@ snapshots:
       '@babel/traverse': 7.26.4
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-transform-modules-systemjs@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14552,6 +14416,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-transform-modules-umd@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14575,6 +14440,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-named-capturing-groups-regex@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14593,6 +14459,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-new-target@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14609,6 +14476,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14625,6 +14493,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-numeric-separator@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14643,6 +14512,7 @@ snapshots:
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-transform-parameters': 7.25.9(@babel/core@7.26.0)
+    optional: true
 
   '@babel/plugin-transform-object-rest-spread@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14670,6 +14540,7 @@ snapshots:
       '@babel/helper-replace-supers': 7.25.9(@babel/core@7.26.0)
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-transform-object-super@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14692,6 +14563,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-optional-catch-binding@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14711,6 +14583,7 @@ snapshots:
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-transform-optional-chaining@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14733,6 +14606,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-parameters@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14752,6 +14626,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-transform-private-methods@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14778,6 +14653,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-transform-private-property-in-object@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14802,6 +14678,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-property-literals@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14858,6 +14735,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
       regenerator-transform: 0.15.2
+    optional: true
 
   '@babel/plugin-transform-regenerator@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14876,6 +14754,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-regexp-modifiers@7.26.0(@babel/core@7.29.7)':
     dependencies:
@@ -14894,6 +14773,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-reserved-words@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14917,6 +14797,7 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -14935,6 +14816,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-shorthand-properties@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14954,6 +14836,7 @@ snapshots:
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/plugin-transform-spread@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14976,6 +14859,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-sticky-regex@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -14992,6 +14876,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-template-literals@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -15008,6 +14893,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-typeof-symbol@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -15047,6 +14933,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-unicode-escapes@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -15064,6 +14951,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-unicode-property-regex@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -15083,6 +14971,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-unicode-regex@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -15102,6 +14991,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.26.0)
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
   '@babel/plugin-transform-unicode-sets-regex@7.25.9(@babel/core@7.29.7)':
     dependencies:
@@ -15130,7 +15020,7 @@ snapshots:
       '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.26.0)
       '@babel/plugin-syntax-import-assertions': 7.26.0(@babel/core@7.26.0)
-      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.26.0)
+      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.26.0)
       '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.26.0)
       '@babel/plugin-transform-arrow-functions': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-async-generator-functions': 7.25.9(@babel/core@7.26.0)
@@ -15190,6 +15080,7 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@babel/preset-env@7.26.0(@babel/core@7.29.7)':
     dependencies:
@@ -15205,7 +15096,7 @@ snapshots:
       '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.25.9(@babel/core@7.29.7)
       '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)
       '@babel/plugin-syntax-import-assertions': 7.26.0(@babel/core@7.29.7)
-      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.7)
       '@babel/plugin-transform-arrow-functions': 7.25.9(@babel/core@7.29.7)
       '@babel/plugin-transform-async-generator-functions': 7.25.9(@babel/core@7.29.7)
@@ -15350,6 +15241,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/types': 7.29.7
       esutils: 2.0.3
+    optional: true
 
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.7)':
     dependencies:
@@ -15462,7 +15354,8 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@discoveryjs/json-ext@0.6.3': {}
+  '@discoveryjs/json-ext@0.6.3':
+    optional: true
 
   '@dnd-kit/accessibility@3.1.1(react@19.0.0)':
     dependencies:
@@ -16024,7 +15917,7 @@ snapshots:
     dependencies:
       string-width: 5.1.2
       string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.1.0
+      strip-ansi: 7.2.0
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
@@ -16042,10 +15935,7 @@ snapshots:
       resolve-from: 5.0.0
     optional: true
 
-  '@istanbuljs/schema@0.1.3': {}
-
-  '@istanbuljs/schema@0.1.6':
-    optional: true
+  '@istanbuljs/schema@0.1.6': {}
 
   '@jest/console@29.7.0':
     dependencies:
@@ -16225,7 +16115,7 @@ snapshots:
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/remapping@2.3.5':
@@ -16244,6 +16134,7 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+    optional: true
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
@@ -16252,7 +16143,7 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
@@ -16263,6 +16154,7 @@ snapshots:
   '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   '@jsonjoy.com/base64@17.67.0(tslib@2.8.1)':
     dependencies:
@@ -16360,6 +16252,7 @@ snapshots:
       hyperdyperid: 1.2.0
       thingies: 1.21.0(tslib@2.8.1)
       tslib: 2.8.1
+    optional: true
 
   '@jsonjoy.com/json-pack@1.21.0(tslib@2.8.1)':
     dependencies:
@@ -16403,6 +16296,7 @@ snapshots:
   '@jsonjoy.com/util@1.5.0(tslib@2.8.1)':
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   '@jsonjoy.com/util@1.9.0(tslib@2.8.1)':
     dependencies:
@@ -16424,7 +16318,8 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
-  '@leichtgewicht/ip-codec@2.0.5': {}
+  '@leichtgewicht/ip-codec@2.0.5':
+    optional: true
 
   '@listr2/prompt-adapter-inquirer@2.0.18(@inquirer/prompts@7.1.0(@types/node@22.19.20))':
     dependencies:
@@ -16840,6 +16735,7 @@ snapshots:
       '@angular/compiler-cli': 19.0.3(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3)
       typescript: 5.6.3
       webpack: 5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)
+    optional: true
 
   '@noble/hashes@1.4.0':
     optional: true
@@ -16921,9 +16817,9 @@ snapshots:
       - bluebird
       - supports-color
 
-  '@nx/angular@20.2.2(@angular-devkit/build-angular@19.0.4(687032b4eee37ef4d96c11dc2ab0877c))(@angular-devkit/core@19.0.4(chokidar@4.0.1))(@angular-devkit/schematics@19.0.4(chokidar@4.0.1))(@babel/traverse@7.26.4)(@rspack/core@1.1.6(@swc/helpers@0.5.23))(@schematics/angular@19.0.4(chokidar@4.0.1))(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@types/node@22.19.20)(@zkochan/js-yaml@0.0.7)(esbuild@0.28.0)(eslint@9.16.0(jiti@2.7.0))(lightningcss@1.32.0)(nx@20.2.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23)))(postcss@8.4.49)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rxjs@7.8.1)(typescript@5.6.3)':
+  '@nx/angular@20.2.2(@angular-devkit/build-angular@19.0.4(9eb2bc13f78f652cd1bf9ab56ac028e9))(@angular-devkit/core@19.0.4(chokidar@4.0.1))(@angular-devkit/schematics@19.0.4(chokidar@4.0.1))(@babel/traverse@7.26.4)(@rspack/core@1.1.6(@swc/helpers@0.5.23))(@schematics/angular@19.0.4(chokidar@4.0.1))(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@types/node@22.19.20)(@zkochan/js-yaml@0.0.7)(esbuild@0.28.0)(eslint@9.16.0(jiti@2.7.0))(lightningcss@1.32.0)(nx@20.2.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23)))(postcss@8.4.49)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rxjs@7.8.1)(typescript@5.6.3)':
     dependencies:
-      '@angular-devkit/build-angular': 19.0.4(687032b4eee37ef4d96c11dc2ab0877c)
+      '@angular-devkit/build-angular': 19.0.4(9eb2bc13f78f652cd1bf9ab56ac028e9)
       '@angular-devkit/core': 19.0.4(chokidar@4.0.1)
       '@angular-devkit/schematics': 19.0.4(chokidar@4.0.1)
       '@nx/devkit': 20.2.2(nx@20.2.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23)))
@@ -17140,7 +17036,7 @@ snapshots:
   '@nx/nx-win32-x64-msvc@20.2.2':
     optional: true
 
-  '@nx/vite@20.2.2(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@22.19.20)(nx@20.2.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23)))(typescript@5.6.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))(vitest@4.1.8(@types/node@22.19.20)(jsdom@22.1.0)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)))':
+  '@nx/vite@20.2.2(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@22.19.20)(nx@20.2.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23)))(typescript@5.6.3)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))(vitest@4.1.8(@types/node@22.19.20)(jsdom@22.1.0)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)))':
     dependencies:
       '@nx/devkit': 20.2.2(nx@20.2.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23)))
       '@nx/js': 20.2.2(@babel/traverse@7.26.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@22.19.20)(nx@20.2.2(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.26)(typescript@5.6.3))(@swc/core@1.5.29(@swc/helpers@0.5.23)))(typescript@5.6.3)
@@ -17149,8 +17045,8 @@ snapshots:
       enquirer: 2.3.6
       minimatch: 9.0.3
       tsconfig-paths: 4.2.0
-      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)
-      vitest: 4.1.8(@types/node@22.19.20)(jsdom@22.1.0)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))
+      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)
+      vitest: 4.1.8(@types/node@22.19.20)(jsdom@22.1.0)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -17786,7 +17682,7 @@ snapshots:
 
   '@rollup/pluginutils@5.1.3(rollup@4.28.1)':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.9
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
@@ -17794,7 +17690,7 @@ snapshots:
 
   '@rollup/pluginutils@5.1.3(rollup@4.61.1)':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.9
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
@@ -18489,7 +18385,8 @@ snapshots:
 
   '@sindresorhus/is@7.2.0': {}
 
-  '@sindresorhus/merge-streams@2.3.0': {}
+  '@sindresorhus/merge-streams@2.3.0':
+    optional: true
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
@@ -18736,6 +18633,7 @@ snapshots:
   '@types/bonjour@3.5.13':
     dependencies:
       '@types/node': 22.19.20
+    optional: true
 
   '@types/chai@5.2.3':
     dependencies:
@@ -18746,6 +18644,7 @@ snapshots:
     dependencies:
       '@types/express-serve-static-core': 5.0.2
       '@types/node': 22.19.20
+    optional: true
 
   '@types/connect@3.4.38':
     dependencies:
@@ -18756,12 +18655,14 @@ snapshots:
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.9
+    optional: true
 
   '@types/eslint@9.6.1':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
+    optional: true
 
   '@types/estree@1.0.6': {}
 
@@ -18792,6 +18693,7 @@ snapshots:
       '@types/qs': 6.9.17
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
+    optional: true
 
   '@types/express@4.17.14':
     dependencies:
@@ -18806,6 +18708,7 @@ snapshots:
       '@types/express-serve-static-core': 4.19.6
       '@types/qs': 6.9.17
       '@types/serve-static': 1.15.7
+    optional: true
 
   '@types/express@4.17.25':
     dependencies:
@@ -18838,6 +18741,7 @@ snapshots:
   '@types/http-proxy@1.17.15':
     dependencies:
       '@types/node': 22.19.20
+    optional: true
 
   '@types/http-proxy@1.17.17':
     dependencies:
@@ -18883,6 +18787,7 @@ snapshots:
   '@types/node-forge@1.3.11':
     dependencies:
       '@types/node': 22.19.20
+    optional: true
 
   '@types/node@17.0.45': {}
 
@@ -18929,7 +18834,8 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
-  '@types/retry@0.12.2': {}
+  '@types/retry@0.12.2':
+    optional: true
 
   '@types/sax@1.2.7':
     dependencies:
@@ -18959,6 +18865,7 @@ snapshots:
   '@types/serve-index@1.9.4':
     dependencies:
       '@types/express': 4.17.14
+    optional: true
 
   '@types/serve-static@1.15.10':
     dependencies:
@@ -18978,6 +18885,7 @@ snapshots:
   '@types/sockjs@0.3.36':
     dependencies:
       '@types/node': 22.19.20
+    optional: true
 
   '@types/speakingurl@13.0.6': {}
 
@@ -19007,6 +18915,7 @@ snapshots:
   '@types/ws@8.5.13':
     dependencies:
       '@types/node': 22.19.20
+    optional: true
 
   '@types/yargs-parser@21.0.3':
     optional: true
@@ -19105,7 +19014,7 @@ snapshots:
       '@typescript-eslint/types': 8.18.0
       '@typescript-eslint/visitor-keys': 8.18.0
       debug: 4.4.3
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.8.2
@@ -19185,25 +19094,24 @@ snapshots:
 
   '@vercel/stega@0.1.2': {}
 
-  '@vitejs/plugin-basic-ssl@1.1.0(vite@5.4.11(@types/node@22.19.20)(less@4.2.0)(lightningcss@1.32.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0))':
-    dependencies:
-      vite: 5.4.11(@types/node@22.19.20)(less@4.2.0)(lightningcss@1.32.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)
-
-  '@vitejs/plugin-basic-ssl@1.1.0(vite@5.4.11(@types/node@22.19.20)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.36.0))':
+  '@vitejs/plugin-basic-ssl@1.1.0(vite@5.4.11(@types/node@22.19.20)(less@4.2.0)(lightningcss@1.32.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.36.0))':
     dependencies:
       vite: 5.4.11(@types/node@22.19.20)(less@4.2.0)(lightningcss@1.32.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.36.0)
+    optional: true
 
   '@vitejs/plugin-basic-ssl@1.1.0(vite@5.4.11(@types/node@22.19.20)(less@4.2.1)(lightningcss@1.32.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0))':
     dependencies:
       vite: 5.4.11(@types/node@22.19.20)(less@4.2.1)(lightningcss@1.32.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)
 
-  '@vitejs/plugin-basic-ssl@1.1.0(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))':
+  '@vitejs/plugin-basic-ssl@1.1.0(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))':
     dependencies:
-      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)
+      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)
+    optional: true
 
   '@vitejs/plugin-basic-ssl@1.1.0(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.82.0)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))':
     dependencies:
       vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.82.0)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)
+    optional: true
 
   '@vitejs/plugin-react@4.7.0(vite@5.4.21(@types/node@22.19.20)(less@4.2.1)(lightningcss@1.32.0)(sass@1.82.0)(stylus@0.64.0)(terser@5.48.0))':
     dependencies:
@@ -19226,13 +19134,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))':
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)
+      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)
     optional: true
 
   '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.82.0)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))':
@@ -19271,20 +19179,26 @@ snapshots:
     dependencies:
       '@webassemblyjs/helper-numbers': 1.13.2
       '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+    optional: true
 
-  '@webassemblyjs/floating-point-hex-parser@1.13.2': {}
+  '@webassemblyjs/floating-point-hex-parser@1.13.2':
+    optional: true
 
-  '@webassemblyjs/helper-api-error@1.13.2': {}
+  '@webassemblyjs/helper-api-error@1.13.2':
+    optional: true
 
-  '@webassemblyjs/helper-buffer@1.14.1': {}
+  '@webassemblyjs/helper-buffer@1.14.1':
+    optional: true
 
   '@webassemblyjs/helper-numbers@1.13.2':
     dependencies:
       '@webassemblyjs/floating-point-hex-parser': 1.13.2
       '@webassemblyjs/helper-api-error': 1.13.2
       '@xtuc/long': 4.2.2
+    optional: true
 
-  '@webassemblyjs/helper-wasm-bytecode@1.13.2': {}
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2':
+    optional: true
 
   '@webassemblyjs/helper-wasm-section@1.14.1':
     dependencies:
@@ -19292,16 +19206,20 @@ snapshots:
       '@webassemblyjs/helper-buffer': 1.14.1
       '@webassemblyjs/helper-wasm-bytecode': 1.13.2
       '@webassemblyjs/wasm-gen': 1.14.1
+    optional: true
 
   '@webassemblyjs/ieee754@1.13.2':
     dependencies:
       '@xtuc/ieee754': 1.2.0
+    optional: true
 
   '@webassemblyjs/leb128@1.13.2':
     dependencies:
       '@xtuc/long': 4.2.2
+    optional: true
 
-  '@webassemblyjs/utf8@1.13.2': {}
+  '@webassemblyjs/utf8@1.13.2':
+    optional: true
 
   '@webassemblyjs/wasm-edit@1.14.1':
     dependencies:
@@ -19313,6 +19231,7 @@ snapshots:
       '@webassemblyjs/wasm-opt': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
       '@webassemblyjs/wast-printer': 1.14.1
+    optional: true
 
   '@webassemblyjs/wasm-gen@1.14.1':
     dependencies:
@@ -19321,6 +19240,7 @@ snapshots:
       '@webassemblyjs/ieee754': 1.13.2
       '@webassemblyjs/leb128': 1.13.2
       '@webassemblyjs/utf8': 1.13.2
+    optional: true
 
   '@webassemblyjs/wasm-opt@1.14.1':
     dependencies:
@@ -19328,6 +19248,7 @@ snapshots:
       '@webassemblyjs/helper-buffer': 1.14.1
       '@webassemblyjs/wasm-gen': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
+    optional: true
 
   '@webassemblyjs/wasm-parser@1.14.1':
     dependencies:
@@ -19337,11 +19258,13 @@ snapshots:
       '@webassemblyjs/ieee754': 1.13.2
       '@webassemblyjs/leb128': 1.13.2
       '@webassemblyjs/utf8': 1.13.2
+    optional: true
 
   '@webassemblyjs/wast-printer@1.14.1':
     dependencies:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
+    optional: true
 
   '@xstate/react@5.0.5(@types/react@18.3.15)(react@19.0.0)(xstate@5.32.0)':
     dependencies:
@@ -19353,9 +19276,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@xtuc/ieee754@1.2.0': {}
+  '@xtuc/ieee754@1.2.0':
+    optional: true
 
-  '@xtuc/long@4.2.2': {}
+  '@xtuc/long@4.2.2':
+    optional: true
 
   '@yarnpkg/lockfile@1.1.0': {}
 
@@ -19425,6 +19350,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       regex-parser: 2.3.0
+    optional: true
 
   adm-zip@0.5.17:
     optional: true
@@ -19440,6 +19366,7 @@ snapshots:
   ajv-formats@2.1.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
+    optional: true
 
   ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
@@ -19453,11 +19380,13 @@ snapshots:
   ajv-keywords@3.5.2(ajv@6.12.6):
     dependencies:
       ajv: 6.12.6
+    optional: true
 
   ajv-keywords@5.1.0(ajv@8.17.1):
     dependencies:
       ajv: 8.17.1
       fast-deep-equal: 3.1.3
+    optional: true
 
   ajv-keywords@5.1.0(ajv@8.20.0):
     dependencies:
@@ -19515,11 +19444,10 @@ snapshots:
     dependencies:
       environment: 1.1.0
 
-  ansi-html-community@0.0.8: {}
+  ansi-html-community@0.0.8:
+    optional: true
 
   ansi-regex@5.0.1: {}
-
-  ansi-regex@6.1.0: {}
 
   ansi-regex@6.2.2: {}
 
@@ -19532,8 +19460,6 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
-
-  ansi-styles@6.2.1: {}
 
   ansi-styles@6.2.3: {}
 
@@ -19672,6 +19598,7 @@ snapshots:
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
       webpack: 5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)
+    optional: true
 
   babel-loader@9.2.1(@babel/core@7.29.7)(webpack@5.107.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
@@ -19725,6 +19652,7 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   babel-plugin-polyfill-corejs2@0.4.12(@babel/core@7.29.7):
     dependencies:
@@ -19752,6 +19680,7 @@ snapshots:
       core-js-compat: 3.39.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   babel-plugin-polyfill-corejs3@0.10.6(@babel/core@7.29.7):
     dependencies:
@@ -19785,6 +19714,7 @@ snapshots:
       '@babel/helper-define-polyfill-provider': 0.6.3(@babel/core@7.26.0)
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   babel-plugin-polyfill-regenerator@0.6.3(@babel/core@7.29.7):
     dependencies:
@@ -19845,32 +19775,33 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.34:
-    optional: true
+  baseline-browser-mapping@2.10.34: {}
 
   basic-auth@2.0.1:
     dependencies:
       safe-buffer: 5.1.2
     optional: true
 
-  batch@0.6.1: {}
+  batch@0.6.1:
+    optional: true
 
   beasties@0.1.0:
     dependencies:
-      css-select: 5.1.0
-      css-what: 6.1.0
+      css-select: 5.2.2
+      css-what: 6.2.2
       dom-serializer: 2.0.0
       domhandler: 5.0.3
       htmlparser2: 9.1.0
       picocolors: 1.1.1
-      postcss: 8.4.49
+      postcss: 8.5.15
       postcss-media-query-parser: 0.2.3
 
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
 
-  big.js@5.2.2: {}
+  big.js@5.2.2:
+    optional: true
 
   binary-extensions@2.3.0: {}
 
@@ -19928,6 +19859,7 @@ snapshots:
     dependencies:
       fast-deep-equal: 3.1.3
       multicast-dns: 7.2.5
+    optional: true
 
   bonjour-service@1.4.0:
     dependencies:
@@ -19982,7 +19914,6 @@ snapshots:
       electron-to-chromium: 1.5.368
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
-    optional: true
 
   bser@2.1.1:
     dependencies:
@@ -20115,8 +20046,7 @@ snapshots:
 
   caniuse-lite@1.0.30001687: {}
 
-  caniuse-lite@1.0.30001793:
-    optional: true
+  caniuse-lite@1.0.30001793: {}
 
   chai@6.2.2: {}
 
@@ -20174,7 +20104,8 @@ snapshots:
 
   chownr@3.0.0: {}
 
-  chrome-trace-event@1.0.4: {}
+  chrome-trace-event@1.0.4:
+    optional: true
 
   ci-info@3.9.0:
     optional: true
@@ -20284,7 +20215,8 @@ snapshots:
   commander@7.2.0:
     optional: true
 
-  common-path-prefix@3.0.0: {}
+  common-path-prefix@3.0.0:
+    optional: true
 
   commondir@1.0.1: {}
 
@@ -20301,6 +20233,7 @@ snapshots:
   compressible@2.0.18:
     dependencies:
       mime-db: 1.53.0
+    optional: true
 
   compression@1.7.5:
     dependencies:
@@ -20313,6 +20246,7 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   compression@1.8.1:
     dependencies:
@@ -20351,7 +20285,8 @@ snapshots:
       write-file-atomic: 3.0.3
       xdg-basedir: 4.0.0
 
-  connect-history-api-fallback@2.0.0: {}
+  connect-history-api-fallback@2.0.0:
+    optional: true
 
   consola@3.2.3: {}
 
@@ -20416,17 +20351,18 @@ snapshots:
 
   copy-webpack-plugin@12.0.2(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)):
     dependencies:
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
       glob-parent: 6.0.2
       globby: 14.0.2
       normalize-path: 3.0.0
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
       webpack: 5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)
+    optional: true
 
   core-js-compat@3.39.0:
     dependencies:
-      browserslist: 4.24.2
+      browserslist: 4.28.2
 
   core-js-compat@3.49.0:
     dependencies:
@@ -20460,10 +20396,11 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
-      js-yaml: 4.1.0
+      js-yaml: 4.2.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.6.3
+    optional: true
 
   crc-32@1.2.2: {}
 
@@ -20543,17 +20480,18 @@ snapshots:
 
   css-loader@7.1.2(@rspack/core@1.1.6(@swc/helpers@0.5.23))(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.49)
-      postcss: 8.4.49
-      postcss-modules-extract-imports: 3.1.0(postcss@8.4.49)
-      postcss-modules-local-by-default: 4.1.0(postcss@8.4.49)
-      postcss-modules-scope: 3.2.1(postcss@8.4.49)
-      postcss-modules-values: 4.0.0(postcss@8.4.49)
+      icss-utils: 5.1.0(postcss@8.5.15)
+      postcss: 8.5.15
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.15)
+      postcss-modules-local-by-default: 4.1.0(postcss@8.5.15)
+      postcss-modules-scope: 3.2.1(postcss@8.5.15)
+      postcss-modules-values: 4.0.0(postcss@8.5.15)
       postcss-value-parser: 4.2.0
       semver: 7.8.2
     optionalDependencies:
       '@rspack/core': 1.1.6(@swc/helpers@0.5.23)
       webpack: 5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)
+    optional: true
 
   css-minimizer-webpack-plugin@5.0.1(esbuild@0.28.0)(lightningcss@1.32.0)(webpack@5.107.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
@@ -20569,14 +20507,6 @@ snapshots:
       lightningcss: 1.32.0
     optional: true
 
-  css-select@5.1.0:
-    dependencies:
-      boolbase: 1.0.0
-      css-what: 6.1.0
-      domhandler: 5.0.3
-      domutils: 3.1.0
-      nth-check: 2.1.1
-
   css-select@5.2.2:
     dependencies:
       boolbase: 1.0.0
@@ -20584,7 +20514,6 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
       nth-check: 2.1.1
-    optional: true
 
   css-to-react-native@3.2.0:
     dependencies:
@@ -20603,10 +20532,7 @@ snapshots:
       mdn-data: 2.0.30
       source-map-js: 1.2.1
 
-  css-what@6.1.0: {}
-
-  css-what@6.2.2:
-    optional: true
+  css-what@6.2.2: {}
 
   cssesc@3.0.0: {}
 
@@ -20801,7 +20727,8 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
-  default-browser-id@5.0.0: {}
+  default-browser-id@5.0.0:
+    optional: true
 
   default-browser-id@5.0.1: {}
 
@@ -20809,6 +20736,7 @@ snapshots:
     dependencies:
       bundle-name: 4.1.0
       default-browser-id: 5.0.0
+    optional: true
 
   default-browser@5.5.0:
     dependencies:
@@ -20840,7 +20768,8 @@ snapshots:
 
   denque@2.1.0: {}
 
-  depd@1.1.2: {}
+  depd@1.1.2:
+    optional: true
 
   depd@2.0.0: {}
 
@@ -20857,9 +20786,6 @@ snapshots:
   detect-libc@1.0.3:
     optional: true
 
-  detect-libc@2.0.3:
-    optional: true
-
   detect-libc@2.1.2: {}
 
   detect-newline@3.1.0:
@@ -20867,7 +20793,8 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
-  detect-node@2.1.0: {}
+  detect-node@2.1.0:
+    optional: true
 
   detect-port@1.6.1:
     dependencies:
@@ -20896,6 +20823,7 @@ snapshots:
   dns-packet@5.6.1:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
+    optional: true
 
   dom-accessibility-api@0.5.16: {}
 
@@ -20917,18 +20845,11 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  domutils@3.1.0:
-    dependencies:
-      dom-serializer: 2.0.0
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-
   domutils@3.2.2:
     dependencies:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
-    optional: true
 
   dot-prop@10.1.0:
     dependencies:
@@ -20979,8 +20900,7 @@ snapshots:
       jake: 10.9.4
     optional: true
 
-  electron-to-chromium@1.5.368:
-    optional: true
+  electron-to-chromium@1.5.368: {}
 
   electron-to-chromium@1.5.72: {}
 
@@ -20993,7 +20913,8 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
-  emojis-list@3.0.0: {}
+  emojis-list@3.0.0:
+    optional: true
 
   encodeurl@1.0.2: {}
 
@@ -21012,6 +20933,7 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
+    optional: true
 
   enhanced-resolve@5.23.0:
     dependencies:
@@ -21026,8 +20948,7 @@ snapshots:
 
   entities@4.5.0: {}
 
-  entities@6.0.1:
-    optional: true
+  entities@6.0.1: {}
 
   env-paths@2.2.1: {}
 
@@ -21050,7 +20971,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-module-lexer@1.7.0: {}
+  es-module-lexer@1.7.0:
+    optional: true
 
   es-module-lexer@2.1.0: {}
 
@@ -21072,7 +20994,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  esbuild-wasm@0.24.0: {}
+  esbuild-wasm@0.24.0:
+    optional: true
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -21215,6 +21138,7 @@ snapshots:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 4.3.0
+    optional: true
 
   eslint-scope@8.2.0:
     dependencies:
@@ -21296,7 +21220,8 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
-  estraverse@4.3.0: {}
+  estraverse@4.3.0:
+    optional: true
 
   estraverse@5.3.0: {}
 
@@ -21314,7 +21239,8 @@ snapshots:
 
   event-target-shim@5.0.1: {}
 
-  eventemitter3@4.0.7: {}
+  eventemitter3@4.0.7:
+    optional: true
 
   eventemitter3@5.0.1: {}
 
@@ -21489,6 +21415,7 @@ snapshots:
   faye-websocket@0.11.4:
     dependencies:
       websocket-driver: 0.7.4
+    optional: true
 
   fb-watchman@2.0.2:
     dependencies:
@@ -21572,6 +21499,7 @@ snapshots:
     dependencies:
       common-path-prefix: 3.0.0
       pkg-dir: 7.0.0
+    optional: true
 
   find-file-up@2.0.1:
     dependencies:
@@ -21601,6 +21529,7 @@ snapshots:
     dependencies:
       locate-path: 7.2.0
       path-exists: 5.0.0
+    optional: true
 
   flat-cache@4.0.1:
     dependencies:
@@ -21613,7 +21542,8 @@ snapshots:
       flatted: 3.4.2
       hookified: 1.5.1
 
-  flat@5.0.2: {}
+  flat@5.0.2:
+    optional: true
 
   flatted@3.4.2: {}
 
@@ -21955,11 +21885,12 @@ snapshots:
   globby@14.0.2:
     dependencies:
       '@sindresorhus/merge-streams': 2.3.0
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
       ignore: 5.3.2
       path-type: 5.0.0
       slash: 5.1.0
       unicorn-magic: 0.1.0
+    optional: true
 
   globby@16.2.0:
     dependencies:
@@ -22022,7 +21953,8 @@ snapshots:
       ufo: 1.6.4
       uncrypto: 0.1.3
 
-  handle-thing@2.0.1: {}
+  handle-thing@2.0.1:
+    optional: true
 
   hard-rejection@2.1.0: {}
 
@@ -22100,6 +22032,7 @@ snapshots:
       obuf: 1.1.2
       readable-stream: 2.3.8
       wbuf: 1.7.3
+    optional: true
 
   html-encoding-sniffer@3.0.0:
     dependencies:
@@ -22109,7 +22042,8 @@ snapshots:
     dependencies:
       whatwg-encoding: 3.1.1
 
-  html-entities@2.5.2: {}
+  html-entities@2.5.2:
+    optional: true
 
   html-escaper@2.0.2:
     optional: true
@@ -22122,7 +22056,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
       domhandler: 5.0.3
-      domutils: 3.1.0
+      domutils: 3.2.2
       entities: 4.5.0
 
   http-assert@1.5.0:
@@ -22133,7 +22067,8 @@ snapshots:
 
   http-cache-semantics@4.1.1: {}
 
-  http-deceiver@1.2.7: {}
+  http-deceiver@1.2.7:
+    optional: true
 
   http-errors@1.6.3:
     dependencies:
@@ -22141,6 +22076,7 @@ snapshots:
       inherits: 2.0.3
       setprototypeof: 1.1.0
       statuses: 1.5.0
+    optional: true
 
   http-errors@1.8.1:
     dependencies:
@@ -22167,7 +22103,8 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-parser-js@0.5.8: {}
+  http-parser-js@0.5.8:
+    optional: true
 
   http-proxy-agent@5.0.0:
     dependencies:
@@ -22195,6 +22132,7 @@ snapshots:
       '@types/express': 4.17.21
     transitivePeerDependencies:
       - debug
+    optional: true
 
   http-proxy-middleware@2.0.9(@types/express@4.17.25):
     dependencies:
@@ -22219,6 +22157,7 @@ snapshots:
       micromatch: 4.0.8
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   http-proxy-middleware@3.0.5:
     dependencies:
@@ -22239,6 +22178,7 @@ snapshots:
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
+    optional: true
 
   http-server@14.1.1:
     dependencies:
@@ -22290,7 +22230,8 @@ snapshots:
 
   humanize-list@1.0.1: {}
 
-  hyperdyperid@1.2.0: {}
+  hyperdyperid@1.2.0:
+    optional: true
 
   i18next@23.16.8:
     dependencies:
@@ -22303,10 +22244,6 @@ snapshots:
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
-
-  icss-utils@5.1.0(postcss@8.4.49):
-    dependencies:
-      postcss: 8.4.49
 
   icss-utils@5.1.0(postcss@8.5.15):
     dependencies:
@@ -22359,7 +22296,8 @@ snapshots:
       wrappy: 1.0.2
     optional: true
 
-  inherits@2.0.3: {}
+  inherits@2.0.3:
+    optional: true
 
   inherits@2.0.4: {}
 
@@ -22391,7 +22329,8 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
-  ipaddr.js@2.2.0: {}
+  ipaddr.js@2.2.0:
+    optional: true
 
   ipaddr.js@2.4.0:
     optional: true
@@ -22475,7 +22414,8 @@ snapshots:
 
   is-natural-number@4.0.1: {}
 
-  is-network-error@1.1.0: {}
+  is-network-error@1.1.0:
+    optional: true
 
   is-number@7.0.0: {}
 
@@ -22485,7 +22425,8 @@ snapshots:
 
   is-plain-obj@1.1.0: {}
 
-  is-plain-obj@3.0.0: {}
+  is-plain-obj@3.0.0:
+    optional: true
 
   is-plain-object@2.0.4:
     dependencies:
@@ -22535,6 +22476,7 @@ snapshots:
   is-wsl@3.1.0:
     dependencies:
       is-inside-container: 1.0.0
+    optional: true
 
   is-wsl@3.1.1:
     dependencies:
@@ -22577,7 +22519,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/parser': 7.29.7
-      '@istanbuljs/schema': 0.1.3
+      '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
       semver: 7.8.2
     transitivePeerDependencies:
@@ -22953,6 +22895,7 @@ snapshots:
       '@types/node': 22.19.20
       merge-stream: 2.0.0
       supports-color: 8.1.1
+    optional: true
 
   jest-worker@29.7.0:
     dependencies:
@@ -23096,8 +23039,7 @@ snapshots:
 
   jsesc@3.0.2: {}
 
-  jsesc@3.1.0:
-    optional: true
+  jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
 
@@ -23148,6 +23090,7 @@ snapshots:
   karma-source-map-support@1.4.0:
     dependencies:
       source-map-support: 0.5.21
+    optional: true
 
   keygrip@1.1.0:
     dependencies:
@@ -23221,6 +23164,7 @@ snapshots:
     dependencies:
       picocolors: 1.1.1
       shell-quote: 1.8.2
+    optional: true
 
   lazystream@1.0.1:
     dependencies:
@@ -23241,6 +23185,7 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 1.1.6(@swc/helpers@0.5.23)
       webpack: 5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)
+    optional: true
 
   less@4.1.3:
     dependencies:
@@ -23270,6 +23215,7 @@ snapshots:
       mime: 1.6.0
       needle: 3.3.1
       source-map: 0.6.1
+    optional: true
 
   less@4.2.1:
     dependencies:
@@ -23304,6 +23250,7 @@ snapshots:
       webpack-sources: 3.2.3
     optionalDependencies:
       webpack: 5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)
+    optional: true
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -23389,7 +23336,7 @@ snapshots:
       eventemitter3: 5.0.1
       log-update: 6.1.0
       rfdc: 1.4.1
-      wrap-ansi: 9.0.0
+      wrap-ansi: 9.0.2
 
   lmdb@3.1.5:
     dependencies:
@@ -23407,7 +23354,8 @@ snapshots:
       '@lmdb/lmdb-win32-x64': 3.1.5
     optional: true
 
-  loader-runner@4.3.0: {}
+  loader-runner@4.3.0:
+    optional: true
 
   loader-runner@4.3.2:
     optional: true
@@ -23417,8 +23365,10 @@ snapshots:
       big.js: 5.2.2
       emojis-list: 3.0.0
       json5: 2.2.3
+    optional: true
 
-  loader-utils@3.3.1: {}
+  loader-utils@3.3.1:
+    optional: true
 
   local-pkg@1.2.1:
     dependencies:
@@ -23442,6 +23392,7 @@ snapshots:
   locate-path@7.2.0:
     dependencies:
       p-locate: 6.0.0
+    optional: true
 
   lodash-es@4.17.21: {}
 
@@ -23480,8 +23431,8 @@ snapshots:
       ansi-escapes: 7.0.0
       cli-cursor: 5.0.0
       slice-ansi: 7.1.0
-      strip-ansi: 7.1.0
-      wrap-ansi: 9.0.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
 
   log4js@6.9.1:
     dependencies:
@@ -23522,7 +23473,7 @@ snapshots:
 
   magic-string@0.30.12:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   magic-string@0.30.21:
     dependencies:
@@ -23617,6 +23568,7 @@ snapshots:
       '@jsonjoy.com/util': 1.5.0(tslib@2.8.1)
       tree-dump: 1.0.2(tslib@2.8.1)
       tslib: 2.8.1
+    optional: true
 
   memfs@4.57.6(tslib@2.8.1):
     dependencies:
@@ -23668,7 +23620,8 @@ snapshots:
 
   mime-db@1.52.0: {}
 
-  mime-db@1.53.0: {}
+  mime-db@1.53.0:
+    optional: true
 
   mime-db@1.54.0: {}
 
@@ -23709,8 +23662,10 @@ snapshots:
       schema-utils: 4.2.0
       tapable: 2.2.1
       webpack: 5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)
+    optional: true
 
-  minimalistic-assert@1.0.1: {}
+  minimalistic-assert@1.0.1:
+    optional: true
 
   minimatch@10.2.5:
     dependencies:
@@ -23877,6 +23832,7 @@ snapshots:
     dependencies:
       dns-packet: 5.6.1
       thunky: 1.1.0
+    optional: true
 
   mute-stream@1.0.0: {}
 
@@ -23912,11 +23868,13 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  negotiator@0.6.4: {}
+  negotiator@0.6.4:
+    optional: true
 
   negotiator@1.0.0: {}
 
-  neo-async@2.6.2: {}
+  neo-async@2.6.2:
+    optional: true
 
   ng-packagr@19.0.1(@angular/compiler-cli@19.0.3(@angular/compiler@19.0.3(@angular/core@19.0.3(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.6.3))(tailwindcss@3.4.16(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(@types/node@22.19.20)(typescript@5.6.3)))(tslib@2.8.1)(typescript@5.6.3):
     dependencies:
@@ -24066,13 +24024,14 @@ snapshots:
     optionalDependencies:
       encoding: 0.1.13
 
-  node-forge@1.3.1: {}
+  node-forge@1.3.1:
+    optional: true
 
   node-forge@1.4.0: {}
 
   node-gyp-build-optional-packages@5.2.2:
     dependencies:
-      detect-libc: 2.0.3
+      detect-libc: 2.1.2
     optional: true
 
   node-gyp-build@4.8.4: {}
@@ -24094,7 +24053,7 @@ snapshots:
 
   node-html-parser@6.1.13:
     dependencies:
-      css-select: 5.1.0
+      css-select: 5.2.2
       he: 1.2.0
 
   node-int64@0.4.0:
@@ -24107,8 +24066,7 @@ snapshots:
 
   node-releases@2.0.19: {}
 
-  node-releases@2.0.47:
-    optional: true
+  node-releases@2.0.47: {}
 
   node-schedule@2.1.1:
     dependencies:
@@ -24284,7 +24242,8 @@ snapshots:
     dependencies:
       rxjs: 7.8.1
 
-  obuf@1.1.2: {}
+  obuf@1.1.2:
+    optional: true
 
   obug@2.1.2: {}
 
@@ -24302,7 +24261,8 @@ snapshots:
     dependencies:
       ee-first: 1.1.1
 
-  on-headers@1.0.2: {}
+  on-headers@1.0.2:
+    optional: true
 
   on-headers@1.1.0:
     optional: true
@@ -24330,6 +24290,7 @@ snapshots:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       is-wsl: 3.1.0
+    optional: true
 
   open@10.2.0:
     dependencies:
@@ -24436,6 +24397,7 @@ snapshots:
   p-limit@4.0.0:
     dependencies:
       yocto-queue: 1.1.1
+    optional: true
 
   p-locate@3.0.0:
     dependencies:
@@ -24452,6 +24414,7 @@ snapshots:
   p-locate@6.0.0:
     dependencies:
       p-limit: 4.0.0
+    optional: true
 
   p-map@1.2.0: {}
 
@@ -24464,6 +24427,7 @@ snapshots:
       '@types/retry': 0.12.2
       is-network-error: 1.1.0
       retry: 0.13.1
+    optional: true
 
   p-try@2.2.0: {}
 
@@ -24530,12 +24494,12 @@ snapshots:
   parse5-html-rewriting-stream@7.0.0:
     dependencies:
       entities: 4.5.0
-      parse5: 7.2.1
+      parse5: 7.3.0
       parse5-sax-parser: 7.0.0
 
   parse5-sax-parser@7.0.0:
     dependencies:
-      parse5: 7.2.1
+      parse5: 7.3.0
 
   parse5@4.0.0:
     optional: true
@@ -24547,7 +24511,6 @@ snapshots:
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
-    optional: true
 
   parseurl@1.3.3: {}
 
@@ -24557,7 +24520,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-exists@5.0.0: {}
+  path-exists@5.0.0:
+    optional: true
 
   path-is-absolute@1.0.1:
     optional: true
@@ -24585,7 +24549,8 @@ snapshots:
 
   path-type@4.0.0: {}
 
-  path-type@5.0.0: {}
+  path-type@5.0.0:
+    optional: true
 
   pathe@1.1.2: {}
 
@@ -24630,7 +24595,7 @@ snapshots:
 
   piscina@4.7.0:
     optionalDependencies:
-      '@napi-rs/nice': 1.0.1
+      '@napi-rs/nice': 1.1.1
 
   piscina@4.8.0:
     optionalDependencies:
@@ -24656,6 +24621,7 @@ snapshots:
   pkg-dir@7.0.0:
     dependencies:
       find-up: 6.3.0
+    optional: true
 
   pkg-types@1.3.1:
     dependencies:
@@ -24794,6 +24760,7 @@ snapshots:
       webpack: 5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)
     transitivePeerDependencies:
       - typescript
+    optional: true
 
   postcss-media-query-parser@0.2.3: {}
 
@@ -24841,21 +24808,18 @@ snapshots:
       postcss-selector-parser: 6.1.2
     optional: true
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.4.49):
-    dependencies:
-      postcss: 8.4.49
-
   postcss-modules-extract-imports@3.1.0(postcss@8.5.15):
     dependencies:
       postcss: 8.5.15
     optional: true
 
-  postcss-modules-local-by-default@4.1.0(postcss@8.4.49):
+  postcss-modules-local-by-default@4.1.0(postcss@8.5.15):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.49)
-      postcss: 8.4.49
+      icss-utils: 5.1.0(postcss@8.5.15)
+      postcss: 8.5.15
       postcss-selector-parser: 7.0.0
       postcss-value-parser: 4.2.0
+    optional: true
 
   postcss-modules-local-by-default@4.2.0(postcss@8.5.15):
     dependencies:
@@ -24865,21 +24829,11 @@ snapshots:
       postcss-value-parser: 4.2.0
     optional: true
 
-  postcss-modules-scope@3.2.1(postcss@8.4.49):
-    dependencies:
-      postcss: 8.4.49
-      postcss-selector-parser: 7.0.0
-
   postcss-modules-scope@3.2.1(postcss@8.5.15):
     dependencies:
       postcss: 8.5.15
       postcss-selector-parser: 7.0.0
     optional: true
-
-  postcss-modules-values@4.0.0(postcss@8.4.49):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.4.49)
-      postcss: 8.4.49
 
   postcss-modules-values@4.0.0(postcss@8.5.15):
     dependencies:
@@ -24980,6 +24934,7 @@ snapshots:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
+    optional: true
 
   postcss-selector-parser@7.1.1:
     dependencies:
@@ -25162,6 +25117,7 @@ snapshots:
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
+    optional: true
 
   range-parser@1.2.1: {}
 
@@ -25353,7 +25309,8 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.26.0
 
-  regex-parser@2.3.0: {}
+  regex-parser@2.3.0:
+    optional: true
 
   regexpu-core@6.2.0:
     dependencies:
@@ -25411,8 +25368,9 @@ snapshots:
       adjust-sourcemap-loader: 4.0.0
       convert-source-map: 1.9.0
       loader-utils: 2.0.4
-      postcss: 8.4.49
+      postcss: 8.5.15
       source-map: 0.6.1
+    optional: true
 
   resolve.exports@2.0.3: {}
 
@@ -25441,7 +25399,8 @@ snapshots:
 
   retry@0.12.0: {}
 
-  retry@0.13.1: {}
+  retry@0.13.1:
+    optional: true
 
   reusify@1.0.4: {}
 
@@ -25539,6 +25498,7 @@ snapshots:
       '@rollup/rollup-win32-ia32-msvc': 4.28.1
       '@rollup/rollup-win32-x64-msvc': 4.28.1
       fsevents: 2.3.3
+    optional: true
 
   rollup@4.61.1:
     dependencies:
@@ -25765,6 +25725,7 @@ snapshots:
       '@rspack/core': 1.1.6(@swc/helpers@0.5.23)
       sass: 1.80.7
       webpack: 5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)
+    optional: true
 
   sass@1.80.7:
     dependencies:
@@ -25772,7 +25733,7 @@ snapshots:
       immutable: 5.0.3
       source-map-js: 1.2.1
     optionalDependencies:
-      '@parcel/watcher': 2.5.0
+      '@parcel/watcher': 2.5.6
 
   sass@1.82.0:
     dependencies:
@@ -25801,6 +25762,7 @@ snapshots:
       '@types/json-schema': 7.0.15
       ajv: 6.12.6
       ajv-keywords: 3.5.2(ajv@6.12.6)
+    optional: true
 
   schema-utils@4.2.0:
     dependencies:
@@ -25808,6 +25770,7 @@ snapshots:
       ajv: 8.17.1
       ajv-formats: 2.1.1(ajv@8.17.1)
       ajv-keywords: 5.1.0(ajv@8.17.1)
+    optional: true
 
   schema-utils@4.3.3:
     dependencies:
@@ -25830,12 +25793,14 @@ snapshots:
     dependencies:
       commander: 2.20.3
 
-  select-hose@2.0.0: {}
+  select-hose@2.0.0:
+    optional: true
 
   selfsigned@2.4.1:
     dependencies:
       '@types/node-forge': 1.3.11
       node-forge: 1.3.1
+    optional: true
 
   selfsigned@5.5.0:
     dependencies:
@@ -25907,6 +25872,7 @@ snapshots:
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
+    optional: true
 
   serialize-javascript@7.0.5: {}
 
@@ -25921,6 +25887,7 @@ snapshots:
       parseurl: 1.3.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   serve-index@1.9.2:
     dependencies:
@@ -25976,7 +25943,8 @@ snapshots:
       gopd: 1.2.0
       has-property-descriptors: 1.0.2
 
-  setprototypeof@1.1.0: {}
+  setprototypeof@1.1.0:
+    optional: true
 
   setprototypeof@1.2.0: {}
 
@@ -25994,7 +25962,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.2: {}
+  shell-quote@1.8.2:
+    optional: true
 
   shell-quote@1.8.4:
     optional: true
@@ -26109,12 +26078,12 @@ snapshots:
 
   slice-ansi@5.0.0:
     dependencies:
-      ansi-styles: 6.2.1
+      ansi-styles: 6.2.3
       is-fullwidth-code-point: 4.0.0
 
   slice-ansi@7.1.0:
     dependencies:
-      ansi-styles: 6.2.1
+      ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.0.0
 
   smart-buffer@4.2.0: {}
@@ -26126,6 +26095,7 @@ snapshots:
       faye-websocket: 0.11.4
       uuid: 8.3.2
       websocket-driver: 0.7.4
+    optional: true
 
   socks-proxy-agent@8.0.5:
     dependencies:
@@ -26157,6 +26127,7 @@ snapshots:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
       webpack: 5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)
+    optional: true
 
   source-map-support@0.5.13:
     dependencies:
@@ -26207,6 +26178,7 @@ snapshots:
       wbuf: 1.7.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   spdy@4.0.2:
     dependencies:
@@ -26217,6 +26189,7 @@ snapshots:
       spdy-transport: 3.0.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   speakingurl@14.0.1: {}
 
@@ -26241,7 +26214,8 @@ snapshots:
 
   standard-as-callback@2.1.0: {}
 
-  statuses@1.5.0: {}
+  statuses@1.5.0:
+    optional: true
 
   statuses@2.0.1: {}
 
@@ -26289,13 +26263,13 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
-      strip-ansi: 7.1.0
+      strip-ansi: 7.2.0
 
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.4.0
       get-east-asian-width: 1.3.0
-      strip-ansi: 7.1.0
+      strip-ansi: 7.2.0
 
   string_decoder@0.10.31: {}
 
@@ -26310,10 +26284,6 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
-
-  strip-ansi@7.1.0:
-    dependencies:
-      ansi-regex: 6.1.0
 
   strip-ansi@7.2.0:
     dependencies:
@@ -26410,6 +26380,7 @@ snapshots:
   supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
+    optional: true
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
@@ -26461,7 +26432,8 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tapable@2.2.1: {}
+  tapable@2.2.1:
+    optional: true
 
   tapable@2.3.3:
     optional: true
@@ -26529,11 +26501,12 @@ snapshots:
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
-      terser: 5.37.0
+      terser: 5.48.0
       webpack: 5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)
     optionalDependencies:
       '@swc/core': 1.5.29(@swc/helpers@0.5.23)
       esbuild: 0.24.0
+    optional: true
 
   terser-webpack-plugin@5.6.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.4.49)(webpack@5.88.0(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.4.49)):
     dependencies:
@@ -26569,13 +26542,7 @@ snapshots:
       acorn: 8.14.0
       commander: 2.20.3
       source-map-support: 0.5.21
-
-  terser@5.37.0:
-    dependencies:
-      '@jridgewell/source-map': 0.3.6
-      acorn: 8.14.0
-      commander: 2.20.3
-      source-map-support: 0.5.21
+    optional: true
 
   terser@5.48.0:
     dependencies:
@@ -26606,6 +26573,7 @@ snapshots:
   thingies@1.21.0(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   thingies@2.6.0(tslib@2.8.1):
     dependencies:
@@ -26628,7 +26596,8 @@ snapshots:
 
   through@2.3.8: {}
 
-  thunky@1.1.0: {}
+  thunky@1.1.0:
+    optional: true
 
   tiny-invariant@1.3.1: {}
 
@@ -26696,13 +26665,15 @@ snapshots:
   tree-dump@1.0.2(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   tree-dump@1.1.0(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  tree-kill@1.2.2: {}
+  tree-kill@1.2.2:
+    optional: true
 
   trim-newlines@3.0.1: {}
 
@@ -26835,7 +26806,8 @@ snapshots:
       es-errors: 1.3.0
       is-typed-array: 1.1.15
 
-  typed-assert@1.0.9: {}
+  typed-assert@1.0.9:
+    optional: true
 
   typedarray-to-buffer@3.1.5:
     dependencies:
@@ -26907,7 +26879,8 @@ snapshots:
 
   unicode-property-aliases-ecmascript@2.1.0: {}
 
-  unicorn-magic@0.1.0: {}
+  unicorn-magic@0.1.0:
+    optional: true
 
   unicorn-magic@0.4.0: {}
 
@@ -27038,7 +27011,6 @@ snapshots:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
-    optional: true
 
   uqr@0.1.3: {}
 
@@ -27133,13 +27105,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-plugin-webfont-dl@3.12.0(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)):
+  vite-plugin-webfont-dl@3.12.0(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)):
     dependencies:
       axios: 1.17.0
       clean-css: 5.3.3
       flat-cache: 6.1.3
       picocolors: 1.1.1
-      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)
+      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -27147,8 +27119,8 @@ snapshots:
   vite@5.4.11(@types/node@22.19.20)(less@4.2.0)(lightningcss@1.32.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.36.0):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.49
-      rollup: 4.28.1
+      postcss: 8.5.15
+      rollup: 4.61.1
     optionalDependencies:
       '@types/node': 22.19.20
       fsevents: 2.3.3
@@ -27157,26 +27129,13 @@ snapshots:
       sass: 1.80.7
       stylus: 0.64.0
       terser: 5.36.0
-
-  vite@5.4.11(@types/node@22.19.20)(less@4.2.0)(lightningcss@1.32.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.4.49
-      rollup: 4.28.1
-    optionalDependencies:
-      '@types/node': 22.19.20
-      fsevents: 2.3.3
-      less: 4.2.0
-      lightningcss: 1.32.0
-      sass: 1.80.7
-      stylus: 0.64.0
-      terser: 5.48.0
+    optional: true
 
   vite@5.4.11(@types/node@22.19.20)(less@4.2.1)(lightningcss@1.32.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.49
-      rollup: 4.28.1
+      postcss: 8.5.15
+      rollup: 4.61.1
     optionalDependencies:
       '@types/node': 22.19.20
       fsevents: 2.3.3
@@ -27189,8 +27148,8 @@ snapshots:
   vite@5.4.21(@types/node@22.19.20)(less@4.2.1)(lightningcss@1.32.0)(sass@1.82.0)(stylus@0.64.0)(terser@5.48.0):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.49
-      rollup: 4.28.1
+      postcss: 8.5.15
+      rollup: 4.61.1
     optionalDependencies:
       '@types/node': 22.19.20
       fsevents: 2.3.3
@@ -27200,7 +27159,7 @@ snapshots:
       stylus: 0.64.0
       terser: 5.48.0
 
-  vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1):
+  vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -27212,7 +27171,7 @@ snapshots:
       esbuild: 0.28.0
       fsevents: 2.3.3
       jiti: 2.7.0
-      less: 4.2.0
+      less: 4.2.1
       sass: 1.80.7
       stylus: 0.64.0
       terser: 5.48.0
@@ -27236,14 +27195,14 @@ snapshots:
       terser: 5.48.0
       yaml: 2.6.1
 
-  vitefu@1.1.3(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)):
+  vitefu@1.1.3(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)):
     optionalDependencies:
-      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)
+      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)
 
-  vitest@4.1.8(@types/node@22.19.20)(jsdom@22.1.0)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)):
+  vitest@4.1.8(@types/node@22.19.20)(jsdom@22.1.0)(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -27260,7 +27219,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.0)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)
+      vite: 8.0.16(@types/node@22.19.20)(esbuild@0.28.0)(jiti@2.7.0)(less@4.2.1)(sass@1.80.7)(stylus@0.64.0)(terser@5.48.0)(yaml@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.20
@@ -27326,6 +27285,7 @@ snapshots:
   wbuf@1.7.3:
     dependencies:
       minimalistic-assert: 1.0.1
+    optional: true
 
   wcwidth@1.0.1:
     dependencies:
@@ -27348,6 +27308,7 @@ snapshots:
       schema-utils: 4.2.0
     optionalDependencies:
       webpack: 5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)
+    optional: true
 
   webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.107.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
@@ -27400,6 +27361,7 @@ snapshots:
       - debug
       - supports-color
       - utf-8-validate
+    optional: true
 
   webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.107.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
@@ -27453,11 +27415,13 @@ snapshots:
       clone-deep: 4.0.1
       flat: 5.0.2
       wildcard: 2.0.1
+    optional: true
 
   webpack-node-externals@3.0.0:
     optional: true
 
-  webpack-sources@3.2.3: {}
+  webpack-sources@3.2.3:
+    optional: true
 
   webpack-sources@3.5.0:
     optional: true
@@ -27472,6 +27436,7 @@ snapshots:
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)
+    optional: true
 
   webpack-virtual-modules@0.6.2: {}
 
@@ -27559,12 +27524,12 @@ snapshots:
   webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0):
     dependencies:
       '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.9
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.14.0
-      browserslist: 4.24.2
+      browserslist: 4.28.2
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.17.1
       es-module-lexer: 1.7.0
@@ -27579,20 +27544,23 @@ snapshots:
       schema-utils: 3.3.0
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.10(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0)(webpack@5.96.1(@swc/core@1.5.29(@swc/helpers@0.5.23))(esbuild@0.24.0))
-      watchpack: 2.4.2
+      watchpack: 2.5.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
       - uglify-js
+    optional: true
 
   websocket-driver@0.7.4:
     dependencies:
       http-parser-js: 0.5.8
       safe-buffer: 5.2.1
       websocket-extensions: 0.1.4
+    optional: true
 
-  websocket-extensions@0.1.4: {}
+  websocket-extensions@0.1.4:
+    optional: true
 
   whatwg-encoding@2.0.0:
     dependencies:
@@ -27655,7 +27623,8 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wildcard@2.0.1: {}
+  wildcard@2.0.1:
+    optional: true
 
   word-wrap@1.2.5: {}
 
@@ -27673,15 +27642,9 @@ snapshots:
 
   wrap-ansi@8.1.0:
     dependencies:
-      ansi-styles: 6.2.1
+      ansi-styles: 6.2.3
       string-width: 5.1.2
-      strip-ansi: 7.1.0
-
-  wrap-ansi@9.0.0:
-    dependencies:
-      ansi-styles: 6.2.1
-      string-width: 7.2.0
-      strip-ansi: 7.1.0
+      strip-ansi: 7.2.0
 
   wrap-ansi@9.0.2:
     dependencies:
@@ -27795,7 +27758,8 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  yocto-queue@1.1.1: {}
+  yocto-queue@1.1.1:
+    optional: true
 
   yoctocolors-cjs@2.1.2: {}
 

--- a/tools/angular-compat/lib.mjs
+++ b/tools/angular-compat/lib.mjs
@@ -348,12 +348,12 @@ export function resolveAngularToolchain(versionSetOrMajor, options = {}) {
     `@angular/core@${angularVersion}`,
     'peerDependencies',
   );
-  const buildAngularVersion = options.includeCli
-    ? resolveAngularPackageVersion('@angular-devkit/build-angular', versionSet)
+  const angularBuildVersion = options.includeCli
+    ? resolveAngularPackageVersion('@angular/build', versionSet, angularVersion)
     : undefined;
-  const buildAngularPeers = buildAngularVersion
+  const angularBuildPeers = angularBuildVersion
     ? resolveNpmJson(
-        `@angular-devkit/build-angular@${buildAngularVersion}`,
+        `@angular/build@${angularBuildVersion}`,
         'peerDependencies',
       )
     : undefined;
@@ -368,7 +368,7 @@ export function resolveAngularToolchain(versionSetOrMajor, options = {}) {
     : undefined;
   const typescriptRange = [
     compilerCliPeers.typescript,
-    buildAngularPeers?.typescript,
+    angularBuildPeers?.typescript,
     ngPackagrPeers?.typescript,
   ]
     .filter(Boolean)
@@ -387,7 +387,7 @@ export function resolveAngularToolchain(versionSetOrMajor, options = {}) {
     angularMajor,
     angularVersion,
     compilerCliVersion,
-    buildAngularVersion,
+    angularBuildVersion,
     cliVersion,
     ngPackagrVersion,
     typescriptVersion,
@@ -411,8 +411,7 @@ function resolveAngularPackageVersion(
   if (
     exactAngularVersion &&
     packageName.startsWith('@angular/') &&
-    packageName !== '@angular/cli' &&
-    packageName !== '@angular-devkit/build-angular'
+    packageName !== '@angular/cli'
   ) {
     return exactAngularVersion;
   }

--- a/tools/angular-compat/test-consumer.mjs
+++ b/tools/angular-compat/test-consumer.mjs
@@ -127,7 +127,7 @@ function writeConsumerProject(
       ...sharedSanityDeps,
     },
     devDependencies: {
-      '@angular-devkit/build-angular': toolchain.buildAngularVersion,
+      '@angular/build': toolchain.angularBuildVersion,
       '@angular/cli': toolchain.cliVersion,
       '@angular/compiler-cli': toolchain.compilerCliVersion,
       '@playwright/test': readPlaywrightVersion(),
@@ -148,7 +148,7 @@ function writeConsumerProject(
         prefix: 'app',
         architect: {
           build: {
-            builder: '@angular-devkit/build-angular:application',
+            builder: '@angular/build:application',
             options: {
               outputPath: `dist/${packageName}`,
               index: 'src/index.html',


### PR DESCRIPTION
## PR Checklist

Replaces direct `@angular-devkit/build-angular` usage with `@angular/build` for the Angular application builder migration.

Closes #

## What is the new behavior?

- `sanity-example` uses `@angular/build:application`, `@angular/build:dev-server`, and `@angular/build:extract-i18n` in `angular.json`.
- Workspace package manifests no longer directly depend on `@angular-devkit/build-angular`; they use `@angular/build` where needed.
- The Angular compatibility consumer generator installs `@angular/build` and emits `@angular/build:application` configs.
- `pnpm-lock.yaml` is refreshed for the dependency graph.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validation run:

- `pnpm --filter=@limitless-angular/angular-compat test`
- `pnpm --filter=@limitless-angular/sanity build`
- `pnpm --filter=sanity-example build`
- `pnpm --filter=analog-sanity-blog-example build`
- `git diff --check`

Note: `pnpm-lock.yaml` can still include `@angular-devkit/build-angular` in transitive peer snapshots from Analog/Nx packages, but direct package declarations and Angular builder configuration now use `@angular/build`.

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
