### PR TITLE
chore: remove tsconfig baseUrl

### DIFF
--- a/tools/angular-compat/test-consumer.mjs
+++ b/tools/angular-compat/test-consumer.mjs
@@ -178,7 +178,6 @@ function writeConsumerProject(
   writeJson(join(workspace, 'tsconfig.json'), {
     compileOnSave: false,
     compilerOptions: {
-      baseUrl: './',
       forceConsistentCasingInFileNames: true,
       importHelpers: true,
       lib: ['esnext', 'dom'],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,35 +11,34 @@
     "lib": ["es2022", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
-    "baseUrl": ".",
     "paths": {
       "@/analog-sanity-blog-example/sanity": [
-        "apps/analog-sanity-blog-example/src/sanity/lib/index.ts"
+        "./apps/analog-sanity-blog-example/src/sanity/lib/index.ts"
       ],
-      "@limitless-angular/sanity": ["packages/sanity/src/index.ts"],
+      "@limitless-angular/sanity": ["./packages/sanity/src/index.ts"],
       "@limitless-angular/sanity/channels": [
-        "packages/sanity/channels/src/index.ts"
+        "./packages/sanity/channels/src/index.ts"
       ],
       "@limitless-angular/sanity/image-loader": [
-        "packages/sanity/image-loader/src/index.ts"
+        "./packages/sanity/image-loader/src/index.ts"
       ],
       "@limitless-angular/sanity/portabletext": [
-        "packages/sanity/portabletext/src/index.ts"
+        "./packages/sanity/portabletext/src/index.ts"
       ],
       "@limitless-angular/sanity/preview-kit": [
-        "packages/sanity/preview-kit/src/index.ts"
+        "./packages/sanity/preview-kit/src/index.ts"
       ],
       "@limitless-angular/sanity/preview-kit-compat": [
-        "packages/sanity/preview-kit-compat/src/index.ts"
+        "./packages/sanity/preview-kit-compat/src/index.ts"
       ],
       "@limitless-angular/sanity/shared": [
-        "packages/sanity/shared/src/index.ts"
+        "./packages/sanity/shared/src/index.ts"
       ],
       "@limitless-angular/sanity/visual-editing": [
-        "packages/sanity/visual-editing/src/index.ts"
+        "./packages/sanity/visual-editing/src/index.ts"
       ],
       "@limitless-angular/sanity/visual-editing-helpers": [
-        "packages/sanity/visual-editing-helpers/src/index.ts"
+        "./packages/sanity/visual-editing-helpers/src/index.ts"
       ]
     }
   },


### PR DESCRIPTION
## Summary

Removes tsconfig-style `baseUrl` usage from both the workspace base config and the generated Angular compatibility consumer config.

- Removed `compilerOptions.baseUrl` from `tsconfig.base.json`
- Updated each workspace `paths` target to use an explicit `./` prefix
- Removed the generated consumer `compilerOptions.baseUrl` from `tools/angular-compat/test-consumer.mjs`

## Why

TypeScript can resolve `paths` without `baseUrl`, but the target paths must be relative when `baseUrl` is absent. This keeps workspace aliases working without enabling root-relative bare imports globally, and keeps the compat consumer aligned with the base config.

## Validation

- `pnpm exec prettier --check tsconfig.base.json`
- `pnpm exec prettier --check tsconfig.base.json tools/angular-compat/test-consumer.mjs`
- `pnpm exec tsc -p tools/tsconfig.json --noEmit --pretty false`
- `pnpm exec tsc -p packages/sanity/tsconfig.lib.json --noEmit --pretty false`
- `pnpm exec tsc -p packages/sanity/tsconfig.spec.json --noEmit --pretty false`
- `pnpm exec tsc -p packages/sanity/preview-kit-compat/tsconfig.lib.json --noEmit --pretty false`
- `pnpm exec tsc -p packages/sanity/visual-editing-helpers/tsconfig.lib.json --noEmit --pretty false`
- `pnpm exec tsc -p apps/sanity-example/tsconfig.app.json --noEmit --pretty false`
- `pnpm exec tsc -p apps/analog-sanity-blog-example/tsconfig.app.json --noEmit --pretty false`
- `pnpm --filter @limitless-angular/angular-compat test`
- `pnpm build`