### PR TITLE
fix(e2e): let Playwright own Studio servers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,17 +314,9 @@ jobs:
         if: steps.affected-presentation-e2e.outputs.run == 'true'
         run: pnpm turbo run e2e --filter=sanity-presentation-e2e
 
-      - name: Stop Sanity Presentation E2E servers
-        if: always() && steps.affected-presentation-e2e.outputs.run == 'true'
-        run: fuser -k 4200/tcp 3333/tcp || true
-
       - name: Run hermetic Sanity Studio E2E
         if: steps.affected-presentation-e2e.outputs.run == 'true'
         run: pnpm turbo run e2e-studio --filter=sanity-presentation-e2e
-
-      - name: Stop hermetic Sanity Studio E2E servers
-        if: always() && steps.affected-presentation-e2e.outputs.run == 'true'
-        run: fuser -k 4200/tcp 3333/tcp || true
 
       - name: Prepare real-project Sanity Studio E2E
         if: ${{ (steps.affected-presentation-e2e.outputs.run == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.run_real_studio) }}

--- a/apps/sanity-presentation-e2e/playwright.config.ts
+++ b/apps/sanity-presentation-e2e/playwright.config.ts
@@ -60,10 +60,8 @@ const previewEnv = useRealProject
 const webServer = [
   {
     cwd: workspaceRoot,
-    command: [
-      ...toShellEnv(previewEnv),
-      'pnpm turbo run serve --filter=analog-sanity-blog-example',
-    ].join(' '),
+    command: `pnpm --dir apps/analog-sanity-blog-example exec vite dev --host 0.0.0.0 --port ${previewPort}`,
+    env: definedEnv(previewEnv),
     url: `${previewURL}/api/presentation-smoke-health`,
     reuseExistingServer: !process.env['CI'],
     timeout: 120_000,
@@ -80,14 +78,12 @@ if (studioMode !== 'off') {
 
   webServer.push({
     cwd: workspaceRoot,
-    command: [
-      ...toShellEnv({
-        SANITY_STUDIO_PROJECT_ID: studioProjectId,
-        SANITY_STUDIO_DATASET: studioDataset,
-        SANITY_STUDIO_PREVIEW_ORIGIN: previewURL,
-      }),
-      'pnpm turbo run serve --filter=sanity-presentation-e2e-studio',
-    ].join(' '),
+    command: `pnpm --dir apps/sanity-presentation-e2e-studio exec sanity dev --host 0.0.0.0 --port ${studioPort}`,
+    env: definedEnv({
+      SANITY_STUDIO_PROJECT_ID: studioProjectId,
+      SANITY_STUDIO_DATASET: studioDataset,
+      SANITY_STUDIO_PREVIEW_ORIGIN: previewURL,
+    }),
     url: studioURL,
     reuseExistingServer: !process.env['CI'],
     timeout: 120_000,
@@ -159,8 +155,12 @@ function existingStorageStatePath(
   return undefined;
 }
 
-function toShellEnv(env: Record<string, string | undefined>): string[] {
-  return Object.entries(env)
-    .filter((entry): entry is [string, string] => entry[1] !== undefined)
-    .map(([key, value]) => `${key}=${JSON.stringify(value)}`);
+function definedEnv(
+  env: Record<string, string | undefined>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(env).filter(
+      (entry): entry is [string, string] => entry[1] !== undefined,
+    ),
+  );
 }


### PR DESCRIPTION
## PR Checklist

No linked issue.

## What is the new behavior?

Playwright now starts the Sanity Presentation E2E preview and Studio servers directly with package-local `pnpm --dir ... exec ...` commands, passing server-specific values through Playwright's structured `env` option. This removes the nested `turbo run serve` persistent-task layer from Playwright's `webServer` lifecycle so Playwright can tear down the servers it starts.

The CI workflow no longer manually kills ports `4200` and `3333` between Presentation E2E runs because the servers are now owned and cleaned up by Playwright.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validated with:

```bash
pnpm turbo run lint --filter=sanity-presentation-e2e
pnpm --dir apps/sanity-presentation-e2e exec playwright test --config playwright.config.ts --list
SANITY_E2E_CDP_ENDPOINT= SANITY_E2E_BROWSER_CHANNEL= pnpm turbo run e2e-studio --filter=sanity-presentation-e2e
```

After the hermetic Studio E2E run finished, ports `4200` and `3333` were no longer listening.

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

