### PR TITLE
feat(sanity): align portabletext with react v6.2.0

### DIFF
--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -227,7 +227,7 @@ We welcome contributions! Check our [Contributing Guide](CONTRIBUTING.md) for de
 
 ## Credits
 
-Adapted from [@portabletext/react v3.1.0](https://github.com/portabletext/react-portabletext/blob/main/CHANGELOG.md#310-2024-05-28) which provided the
+Adapted from [@portabletext/react v6.2.0](https://github.com/portabletext/react-portabletext/releases/tag/v6.2.0) which provided the
 vast majority of node rendering logic.
 
 ## License

--- a/packages/sanity/portabletext/README.md
+++ b/packages/sanity/portabletext/README.md
@@ -5,7 +5,7 @@
 
 Render [Portable Text](https://portabletext.org/) with Angular.
 
-Based on [@portabletext/react v3.1.0](https://github.com/portabletext/react-portabletext/blob/main/CHANGELOG.md#310-2024-05-28).
+Based on [@portabletext/react v6.2.0](https://github.com/portabletext/react-portabletext/releases/tag/v6.2.0).
 
 ## Demo
 
@@ -17,6 +17,7 @@ You can also see the example project in the monorepo: [`apps/sanity-example`](/a
 
 - [Installation](#installation)
 - [Basic usage](#basic-usage)
+- [Inputs](#inputs)
 - [Styling](#styling-the-output)
 - [Customizing components](#customizing-components)
 - [Available components](#available-components)
@@ -26,6 +27,7 @@ You can also see the example project in the monorepo: [`apps/sanity-example`](/a
   - [list](#list)
   - [listItem](#listitem)
   - [hardBreak](#hardbreak)
+  - [Fallback components](#fallback-components)
 - [Architecture Documentation](./ARCHITECTURE.md)
 
 ## Installation
@@ -56,6 +58,15 @@ export class YourComponent {
   };
 }
 ```
+
+## Inputs
+
+The Angular component follows the `@portabletext/react` prop contract with Angular inputs:
+
+- `value`: a single Portable Text node, an array of nodes, `null`, or `undefined`. `null` and `undefined` render nothing.
+- `components`: optional Angular component overrides.
+- `onMissingComponent`: warning handler, or `false` to disable warnings.
+- `listNestingMode`: optional `ListNestMode` (`html` by default, or `direct`).
 
 ## Styling the output
 
@@ -714,6 +725,33 @@ The `listItem` property can also be set to a single Angular component, which wou
 Component to use for rendering "hard breaks", eg `\n` inside of text spans.
 
 Will by default render a `<br />`. Pass `false` to render as-is (`\n`)
+
+### Fallback components
+
+You can also override the fallback components used when no renderer is registered:
+
+- `unknownType`
+- `unknownMark`
+- `unknownBlockStyle`
+- `unknownList`
+- `unknownListItem`
+
+For example:
+
+```typescript
+import { Component } from '@angular/core';
+import { PortableTextComponents, PortableTextTypeComponent } from '@limitless-angular/sanity/portabletext';
+
+@Component({
+  selector: 'div',
+  template: `Unknown type: {{ value()._type }}`,
+})
+export class UnknownTypeComponent extends PortableTextTypeComponent {}
+
+export const components: PortableTextComponents = {
+  unknownType: UnknownTypeComponent,
+};
+```
 
 ## Rendering Plain Text
 

--- a/packages/sanity/portabletext/src/components/children.component.ts
+++ b/packages/sanity/portabletext/src/components/children.component.ts
@@ -20,7 +20,7 @@ import { RenderNode } from '../directives/render-node.directive';
       <ng-container
         [renderNode]="child"
         [isInline]="child.isInline ?? isInline ?? true"
-        [index]="index"
+        [index]="child.index ?? index"
       />
     }
   </ng-template>`,
@@ -30,7 +30,7 @@ import { RenderNode } from '../directives/render-node.directive';
 export class ChildrenComponent {
   template = viewChild.required<
     TemplateRef<{
-      children: (TypedObject & { isInline?: boolean })[];
+      children: (TypedObject & { index?: number; isInline?: boolean })[];
       isInline?: boolean;
     }>
   >(TemplateRef);

--- a/packages/sanity/portabletext/src/components/defaults/default-components.ts
+++ b/packages/sanity/portabletext/src/components/defaults/default-components.ts
@@ -1,22 +1,35 @@
-import { PortableTextComponents } from '../../types';
+/* eslint-disable @angular-eslint/component-selector */
+/* eslint-disable @angular-eslint/component-class-suffix */
+import { Component } from '@angular/core';
+import { PortableTextAngularComponents } from '../../types';
 import { defaultBlockStyles } from './blocks';
 import { defaultLists } from './list';
 import { DefaultListItem } from './list';
 import { defaultMarks } from './marks';
 import {
+  DefaultUnknownType,
   DefaultUnknownMark,
   DefaultUnknownBlockStyle,
   DefaultUnknownList,
   DefaultUnknownListItem,
 } from './unknown';
-export const defaultComponents: PortableTextComponents = {
+
+@Component({
+  selector: 'br',
+  template: '',
+})
+export class DefaultHardBreak {}
+
+export const defaultComponents: PortableTextAngularComponents = {
   types: {},
 
   block: defaultBlockStyles,
   marks: defaultMarks,
   list: defaultLists,
   listItem: DefaultListItem,
+  hardBreak: DefaultHardBreak,
 
+  unknownType: DefaultUnknownType,
   unknownMark: DefaultUnknownMark,
   unknownList: DefaultUnknownList,
   unknownListItem: DefaultUnknownListItem,

--- a/packages/sanity/portabletext/src/components/defaults/unknown.ts
+++ b/packages/sanity/portabletext/src/components/defaults/unknown.ts
@@ -1,14 +1,27 @@
 /* eslint-disable @angular-eslint/component-selector */
 /* eslint-disable @angular-eslint/component-class-suffix */
-import { Component } from '@angular/core';
+import { Component, computed } from '@angular/core';
 import {
   PortableTextBlockComponent,
   PortableTextListComponent,
   PortableTextListItemComponent,
   PortableTextMarkComponent,
+  PortableTextTypeComponent,
 } from '../../directives/portable-text-directives';
+import { unknownTypeWarning } from '../../warnings';
 
 const template = '<ng-container #children />';
+
+@Component({
+  selector: 'span',
+  template: `{{ warning() }}`,
+  host: { '[style.display]': '"none"' },
+})
+export class DefaultUnknownType extends PortableTextTypeComponent {
+  protected readonly warning = computed(() =>
+    unknownTypeWarning(this.value()._type),
+  );
+}
 
 @Component({
   selector: 'span,span[data-unknown="true"]',

--- a/packages/sanity/portabletext/src/components/portable-text.component.ts
+++ b/packages/sanity/portabletext/src/components/portable-text.component.ts
@@ -13,7 +13,11 @@ import {
 } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
 
-import { LIST_NEST_MODE_HTML, nestLists } from '@portabletext/toolkit';
+import {
+  LIST_NEST_MODE_HTML,
+  nestLists,
+  type ToolkitListNestMode,
+} from '@portabletext/toolkit';
 import {
   ArbitraryTypedObject,
   PortableTextBlock,
@@ -22,6 +26,7 @@ import {
 
 import {
   MissingComponentHandler,
+  PortableTextAngularComponents,
   PortableTextComponents,
   RenderNodeContext,
 } from '../types';
@@ -66,16 +71,16 @@ import { TextComponent } from './text.component';
       }
     </ng-template>
 
-    <ng-template #unknownTmpl let-node="node" let-isInline="isInline">
+    <ng-template
+      #unknownTmpl
+      let-node="node"
+      let-isInline="isInline"
+      let-warning="warning"
+    >
       @if (isInline) {
-        <span style="display: none" aria-hidden="true">{{
-          'Unknown block type: ' + node._type
-        }}</span>
+        <span style="display: none">{{ warning }}</span>
       } @else {
-        <!-- display: inline -->
-        <div style="display: none" aria-hidden="true">{{
-          'Unknown block type: ' + node._type
-        }}</div>
+        <div style="display: none">{{ warning }}</div>
       }
     </ng-template>
   `,
@@ -95,20 +100,26 @@ export class PortableTextComponent<
    * The Portable Text content to render.
    * Can be a single block or an array of blocks.
    */
-  value = input.required<B | B[]>();
+  value = input.required<B | B[] | null | undefined>();
 
   /**
    * Custom components to override the default rendering.
    * @see PortableTextComponents
    */
-  componentOverrides = input<Partial<PortableTextComponents>>(
-    {},
+  componentOverrides = input<PortableTextComponents<B> | undefined>(
+    undefined,
     // eslint-disable-next-line @angular-eslint/no-input-rename
     { alias: 'components' },
   );
 
   /**
-   * Template reference for rendering nodes
+   * Determines whether lists are nested inside list items (`html`) or as a
+   * direct child of another list (`direct`).
+   */
+  listNestingMode = input<ToolkitListNestMode>();
+
+  /**
+   * @internal Template reference for rendering nodes.
    */
   renderNode =
     viewChild.required<TemplateRef<RenderNodeContext<B>>>('renderNode');
@@ -126,17 +137,20 @@ export class PortableTextComponent<
   /**
    * Merged components from default and overrides
    */
-  availableComponents = computed(() =>
-    mergeComponents(defaultComponents, this.componentOverrides()),
-  );
+  availableComponents = computed<PortableTextAngularComponents<B>>(() => {
+    const overrides = this.componentOverrides();
+    return overrides
+      ? mergeComponents(defaultComponents, overrides)
+      : (defaultComponents as PortableTextAngularComponents<B>);
+  });
 
   /**
    * Template reference for rendering unknown block types
    */
   unknownTmpl =
-    viewChild.required<TemplateRef<{ node: TypedObject; isInline: boolean }>>(
-      'unknownTmpl',
-    );
+    viewChild.required<
+      TemplateRef<{ node: TypedObject; isInline: boolean; warning: string }>
+    >('unknownTmpl');
 
   /**
    * Creates a template for rendering children
@@ -160,8 +174,21 @@ export class PortableTextComponent<
    * Handles both single blocks and arrays of blocks
    */
   nestedBlocks = computed(() => {
-    const blocks = Array.isArray(this.value()) ? this.value() : [this.value()];
-    return nestLists(blocks as TypedObject[], LIST_NEST_MODE_HTML);
+    const input = this.value();
+    let blocks: B[];
+
+    if (Array.isArray(input)) {
+      blocks = input;
+    } else if (input == null) {
+      blocks = [];
+    } else {
+      blocks = [input];
+    }
+
+    return nestLists(
+      blocks as TypedObject[],
+      this.listNestingMode() || LIST_NEST_MODE_HTML,
+    );
   });
 
   /**

--- a/packages/sanity/portabletext/src/components/text.component.ts
+++ b/packages/sanity/portabletext/src/components/text.component.ts
@@ -15,9 +15,8 @@ import { PortableTextComponents } from '../types';
   // prettier-ignore
   template: `<ng-template let-node let-components="components">
     @if (node.text === '\\n') {
-      @if (components.hardBreak === undefined) {<br />}
-      @else if (components.hardBreak === false) {{{ '\\n' }}}
-      @else {<ng-container *ngComponentOutlet="components.hardBreak" />}
+      @if (components.hardBreak) {<ng-container *ngComponentOutlet="components.hardBreak" />}
+      @else {{{ '\\n' }}}
     } @else {{{ node.text }}}
   </ng-template>`,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/packages/sanity/portabletext/src/directives/portable-text-directives.ts
+++ b/packages/sanity/portabletext/src/directives/portable-text-directives.ts
@@ -24,7 +24,8 @@ import { PortableTextComponent } from '../components/portable-text.component';
 export class DynamicPortableTextContent<Node extends TypedObject = TypedObject>
   implements AfterViewInit
 {
-  children = input.required<(TypedObject & { isInline?: boolean })[]>();
+  children =
+    input.required<(TypedObject & { index?: number; isInline?: boolean })[]>();
   container = viewChild<ViewContainerRef, ViewContainerRef>('children', {
     read: ViewContainerRef,
   });
@@ -94,6 +95,11 @@ export class PortableTextTypeComponent<
   value = input.required<T>();
 
   /**
+   * Index within its parent.
+   */
+  index = input(0);
+
+  /**
    * Whether this node is "inline" - ie as a child of a text block,
    * alongside text spans, or a block in and of itself.
    */
@@ -103,16 +109,20 @@ export class PortableTextTypeComponent<
 // eslint-disable-next-line @angular-eslint/directive-selector
 @Directive({ selector: '[portableTextBlock]' })
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
-export class PortableTextBlockComponent extends PortableTextTypeComponent<PortableTextBlock> {}
+export class PortableTextBlockComponent<
+  T extends TypedObject = PortableTextBlock,
+> extends PortableTextTypeComponent<T> {}
+
+// eslint-disable-next-line @angular-eslint/directive-selector
+@Directive({ selector: '[portableTextList]' })
+// eslint-disable-next-line @angular-eslint/directive-class-suffix
+export class PortableTextListComponent<
+  T extends TypedObject = PortableTextListBlock,
+> extends PortableTextTypeComponent<T> {}
 
 // eslint-disable-next-line @angular-eslint/directive-selector
 @Directive({ selector: '[portableTextListItem]' })
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
-export class PortableTextListComponent extends PortableTextTypeComponent<PortableTextListBlock> {}
-
-// eslint-disable-next-line @angular-eslint/directive-selector
-@Directive({ selector: '[portableTextListItem]' })
-// eslint-disable-next-line @angular-eslint/directive-class-suffix
-export class PortableTextListItemComponent extends PortableTextTypeComponent<PortableTextListItemBlock> {
-  index = input.required<number>();
-}
+export class PortableTextListItemComponent<
+  T extends TypedObject = PortableTextListItemBlock,
+> extends PortableTextTypeComponent<T> {}

--- a/packages/sanity/portabletext/src/index.ts
+++ b/packages/sanity/portabletext/src/index.ts
@@ -1,4 +1,7 @@
-export { PortableTextComponent } from './components/portable-text.component';
+export {
+  PortableTextComponent,
+  PortableTextComponent as PortableText,
+} from './components/portable-text.component';
 export {
   PortableTextTypeComponent,
   PortableTextMarkComponent,
@@ -6,6 +9,30 @@ export {
   PortableTextListItemComponent,
   PortableTextListComponent,
 } from './directives/portable-text-directives';
-export { PortableTextComponents } from './types';
+export { defaultComponents } from './components/defaults/default-components';
+export { mergeComponents } from './utils/merge';
+export type {
+  AngularPortableTextList,
+  AngularPortableTextListItem,
+  DefaultPortableTextBlockStyle,
+  DefaultPortableTextListItem,
+  DefaultPortableTextMark,
+  InferComponents,
+  InferStrictComponents,
+  InferValue,
+  MissingComponentHandler,
+  NodeType,
+  PortableTextAngularComponent,
+  PortableTextAngularComponents,
+  PortableTextBlockComponentType,
+  PortableTextComponents,
+  PortableTextListBlock,
+  PortableTextListComponentType,
+  PortableTextListItemComponentType,
+  PortableTextMarkComponentType,
+  PortableTextProps,
+  UnknownNodeType,
+} from './types';
+export type { ToolkitListNestMode as ListNestMode } from '@portabletext/toolkit';
 export { toPlainText } from '@portabletext/toolkit';
 export type { PortableTextBlock } from '@portabletext/types';

--- a/packages/sanity/portabletext/src/services/block-handler.service.ts
+++ b/packages/sanity/portabletext/src/services/block-handler.service.ts
@@ -4,7 +4,7 @@ import { memoize } from 'lodash-es';
 
 import {
   MissingComponentHandler,
-  PortableTextComponents,
+  PortableTextAngularComponents,
   Serializable,
 } from '../types';
 import { serializeBlock } from '../utils';
@@ -34,10 +34,12 @@ export class BlockHandlerService {
   getComponent(
     node: PortableTextBlock,
     missingHandler: MissingComponentHandler,
-    components: Required<PortableTextComponents>,
+    components: PortableTextAngularComponents,
   ) {
     const style = node.style ?? 'normal';
-    const Block = components.block?.[style] ?? components.unknownBlockStyle;
+    const renderer = components.block;
+    const handler = typeof renderer === 'function' ? renderer : renderer[style];
+    const Block = handler ?? components.unknownBlockStyle;
 
     if (Block === components.unknownBlockStyle) {
       missingHandler(unknownBlockStyleWarning(style), {
@@ -64,8 +66,12 @@ export class BlockHandlerService {
   ): Record<string, unknown> {
     return {
       value: node,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      children: this.#getChildren({ node, index: index!, isInline }),
+      children: this.#getChildren({
+        node,
+        index: index ?? 0,
+        isInline,
+      }),
+      index,
       isInline,
     };
   }

--- a/packages/sanity/portabletext/src/services/list-handler.service.ts
+++ b/packages/sanity/portabletext/src/services/list-handler.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import {
   MissingComponentHandler,
-  PortableTextComponents,
+  PortableTextAngularComponents,
   PortableTextListBlock,
 } from '../types';
 import { unknownListStyleWarning } from '../warnings';
@@ -30,9 +30,12 @@ export class ListHandlerService {
   getComponent(
     node: PortableTextListBlock,
     missingHandler: MissingComponentHandler,
-    components: Required<PortableTextComponents>,
+    components: PortableTextAngularComponents,
   ) {
-    const List = components.list?.[node.listItem] ?? components.unknownList;
+    const renderer = components.list;
+    const handler =
+      typeof renderer === 'function' ? renderer : renderer[node.listItem];
+    const List = handler ?? components.unknownList;
 
     if (List === components.unknownList) {
       const style = node.listItem || 'bullet';
@@ -55,13 +58,19 @@ export class ListHandlerService {
    */
   getInputProps(
     node: PortableTextListBlock,
-    _index: number | undefined,
-    isInline: boolean,
+    index: number | undefined,
+    _isInline: boolean,
   ): Record<string, unknown> {
     return {
-      children: node.children,
+      children: node.children.map((child, childIndex) => ({
+        ...child,
+        _key: child._key ?? `li-${index}-${childIndex}`,
+        index: childIndex,
+        isInline: false,
+      })),
       value: node,
-      isInline,
+      index,
+      isInline: false,
     };
   }
 }

--- a/packages/sanity/portabletext/src/services/list-item-handler.service.ts
+++ b/packages/sanity/portabletext/src/services/list-item-handler.service.ts
@@ -8,7 +8,7 @@ import { memoize } from 'lodash-es';
 
 import {
   MissingComponentHandler,
-  PortableTextComponents,
+  PortableTextAngularComponents,
   Serializable,
 } from '../types';
 import { serializeBlock } from '../utils';
@@ -41,7 +41,7 @@ export class ListItemHandlerService {
       PortableTextSpan
     >,
     missingHandler: MissingComponentHandler,
-    components: Required<PortableTextComponents>,
+    components: PortableTextAngularComponents,
   ) {
     const renderer = components.listItem;
     const handler =
@@ -76,7 +76,7 @@ export class ListItemHandlerService {
       // Wrap any other style in whatever the block serializer says to use
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { listItem, ...blockNode } = node;
-      children = [{ ...blockNode, isInline: false }];
+      children = [{ ...blockNode, index, isInline: false }];
     }
 
     return children;
@@ -96,14 +96,13 @@ export class ListItemHandlerService {
       PortableTextSpan
     >,
     index: number | undefined,
-    isInline: boolean,
+    _isInline: boolean,
   ): Record<string, unknown> {
     return {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      children: this.getChildren({ node, index: index! }),
+      children: this.getChildren({ node, index: index ?? 0 }),
       value: node,
       index,
-      isInline,
+      isInline: false,
     };
   }
 }

--- a/packages/sanity/portabletext/src/services/node-resolver.service.ts
+++ b/packages/sanity/portabletext/src/services/node-resolver.service.ts
@@ -9,18 +9,27 @@ import { BlockHandlerService } from './block-handler.service';
 import { ListHandlerService } from './list-handler.service';
 import { ListItemHandlerService } from './list-item-handler.service';
 import { SpanHandlerService } from './span-handler.service';
-import { MissingComponentHandler, PortableTextComponents } from '../types';
+import {
+  MissingComponentHandler,
+  PortableTextAngularComponents,
+} from '../types';
 import { unknownTypeWarning } from '../warnings';
+import { DefaultUnknownType } from '../components/defaults/unknown';
 
 const CustomComponentHandler = {
   canHandle: hasCustomComponentForNode,
   getComponent: (
     node: TypedObject,
     _: unknown,
-    components: Required<PortableTextComponents>,
+    components: PortableTextAngularComponents,
   ) => getCustomComponentForNode(node, components),
-  getInputProps: (node: TypedObject, _: unknown, isInline: boolean) => ({
+  getInputProps: (
+    node: TypedObject,
+    index: number | undefined,
+    isInline: boolean,
+  ) => ({
     value: node,
+    index,
     isInline,
   }),
 };
@@ -45,18 +54,22 @@ export function injectResolveNode() {
    * @param isInline Whether the node is inline
    * @returns An object containing the template and context for rendering the node
    */
-  return (
+  return function resolveNode(
     node: TypedObject,
-    components: Required<PortableTextComponents>,
+    components: PortableTextAngularComponents,
     missingHandler: MissingComponentHandler,
     templates: {
       nodeRenderer: TemplateRef<unknown>;
       text: TemplateRef<unknown>;
-      unknown: TemplateRef<{ node: TypedObject; isInline: boolean }>;
+      unknown: TemplateRef<{
+        node: TypedObject;
+        isInline: boolean;
+        warning: string;
+      }>;
     },
     index?: number,
     isInline = false,
-  ) => {
+  ) {
     for (const handler of handlers) {
       if (!handler.canHandle(node, components)) {
         continue;
@@ -67,7 +80,11 @@ export function injectResolveNode() {
         missingHandler,
         components,
       );
-      const inputProps = handler.getInputProps(node as never, index, isInline);
+      const inputProps = handler.getInputProps(
+        node as never,
+        index,
+        isInline,
+      );
       return {
         template: templates.nodeRenderer,
         context: { componentType, inputProps },
@@ -82,12 +99,30 @@ export function injectResolveNode() {
       };
     }
 
-    missingHandler(unknownTypeWarning(node._type), {
+    const warning = unknownTypeWarning(node._type);
+    missingHandler(warning, {
       nodeType: 'block',
       type: node._type,
     });
 
-    return { template: templates.unknown, context: { node, isInline } };
+    if (components.unknownType === DefaultUnknownType) {
+      return {
+        template: templates.unknown,
+        context: { node, isInline, warning },
+      };
+    }
+
+    return {
+      template: templates.nodeRenderer,
+      context: {
+        componentType: components.unknownType,
+        inputProps: {
+          value: node,
+          index,
+          isInline,
+        },
+      },
+    };
   };
 }
 
@@ -100,7 +135,7 @@ export function injectResolveNode() {
  */
 function getCustomComponentForNode(
   node: TypedObject,
-  components: Required<PortableTextComponents>,
+  components: PortableTextAngularComponents,
 ): Type<unknown> {
   return components.types[node._type] as Type<unknown>;
 }
@@ -114,7 +149,7 @@ function getCustomComponentForNode(
  */
 function hasCustomComponentForNode(
   node: TypedObject,
-  components: Required<PortableTextComponents>,
+  components: PortableTextAngularComponents,
 ): boolean {
   return node._type in components.types;
 }

--- a/packages/sanity/portabletext/src/services/node-resolver.service.ts
+++ b/packages/sanity/portabletext/src/services/node-resolver.service.ts
@@ -80,11 +80,7 @@ export function injectResolveNode() {
         missingHandler,
         components,
       );
-      const inputProps = handler.getInputProps(
-        node as never,
-        index,
-        isInline,
-      );
+      const inputProps = handler.getInputProps(node as never, index, isInline);
       return {
         template: templates.nodeRenderer,
         context: { componentType, inputProps },

--- a/packages/sanity/portabletext/src/services/span-handler.service.ts
+++ b/packages/sanity/portabletext/src/services/span-handler.service.ts
@@ -6,7 +6,10 @@ import {
 } from '@portabletext/toolkit';
 
 import { unknownMarkWarning } from '../warnings';
-import { MissingComponentHandler, PortableTextComponents } from '../types';
+import {
+  MissingComponentHandler,
+  PortableTextAngularComponents,
+} from '../types';
 
 /**
  * Service for handling span nodes in Portable Text
@@ -31,7 +34,7 @@ export class SpanHandlerService {
   getComponent(
     node: ToolkitNestedPortableTextSpan,
     missingHandler: MissingComponentHandler,
-    components: Required<PortableTextComponents>,
+    components: PortableTextAngularComponents,
   ) {
     const Span = components.marks?.[node.markType] ?? components.unknownMark;
 

--- a/packages/sanity/portabletext/src/tests/fixtures/070-malformed-data.ts
+++ b/packages/sanity/portabletext/src/tests/fixtures/070-malformed-data.ts
@@ -8,7 +8,7 @@ const missingSpanChildren = {
     },
   ],
   output:
-    '<div aria-hidden="true" style="display: none;">Unknown block type: block</div>',
+    '<div style="display: none;">[@limitless-angular/sanity/portabletext] Unknown block type &quot;block&quot;, specify a component for it in the `components.types` prop</div>',
 };
 
 const invalidMarkReferences = {
@@ -41,7 +41,7 @@ const invalidBlockType = {
     },
   ],
   output:
-    '<div aria-hidden="true" style="display: none;">Unknown block type: not-a-valid-block-type</div>',
+    '<div style="display: none;">[@limitless-angular/sanity/portabletext] Unknown block type &quot;not-a-valid-block-type&quot;, specify a component for it in the `components.types` prop</div>',
 };
 
 export default {

--- a/packages/sanity/portabletext/src/tests/helpers.ts
+++ b/packages/sanity/portabletext/src/tests/helpers.ts
@@ -2,6 +2,7 @@ import { expect } from 'vitest';
 import { aliasedInput, render } from '@testing-library/angular';
 import { PortableTextComponent } from '../components/portable-text.component';
 import { TypedObject } from '@portabletext/types';
+import type { ToolkitListNestMode } from '@portabletext/toolkit';
 import { PortableTextComponents, MissingComponentHandler } from '../types';
 
 const cleanAngularHTML = (html: string) => {
@@ -46,14 +47,21 @@ export const assertHTML = (container: Element, expectedHTML: string) => {
 };
 
 export const renderPortableText = (
-  input: TypedObject | TypedObject[],
-  components: Partial<PortableTextComponents> = {},
+  input: TypedObject | TypedObject[] | null | undefined,
+  components: PortableTextComponents = {},
   onMissingComponent: MissingComponentHandler | false = false,
-) =>
-  render(PortableTextComponent, {
+  listNestingMode?: ToolkitListNestMode,
+) => {
+  const inputs = {
+    value: input,
+    ...aliasedInput('components', components),
+    onMissingComponent,
+    ...(listNestingMode ? { listNestingMode } : {}),
+  };
+
+  return render(PortableTextComponent, {
     inputs: {
-      value: input,
-      ...aliasedInput('components', components),
-      onMissingComponent,
+      ...inputs,
     },
   });
+};

--- a/packages/sanity/portabletext/src/tests/portable-text.component.spec.ts
+++ b/packages/sanity/portabletext/src/tests/portable-text.component.spec.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { render } from '@testing-library/angular';
+import { LIST_NEST_MODE_DIRECT } from '@portabletext/toolkit';
 import { expect, test, describe } from 'vitest';
 import * as fixtures from './fixtures';
 import { MissingComponentHandler, PortableTextComponents } from '../types';
@@ -16,7 +17,13 @@ import { QuoteComponent } from './test-components/QuoteComponent';
 import { LinkComponent } from './test-components/LinkComponent';
 import { CodeComponent } from './test-components/CodeComponent';
 import { PortableTextComponent } from '../components/portable-text.component';
-import { PortableTextMarkComponent } from '../directives/portable-text-directives';
+import {
+  PortableTextBlockComponent,
+  PortableTextListComponent,
+  PortableTextListItemComponent,
+  PortableTextMarkComponent,
+  PortableTextTypeComponent,
+} from '../directives/portable-text-directives';
 
 describe('PortableTextComponent', () => {
   test('builds empty tree on empty block', async () => {
@@ -85,6 +92,102 @@ describe('PortableTextComponent', () => {
     assertHTML(result.container, output);
   });
 
+  test('can render lists with direct nesting mode', async () => {
+    const input = [
+      {
+        _type: 'block',
+        _key: 'one',
+        markDefs: [],
+        level: 1,
+        children: [{ _type: 'span', marks: [], text: 'One' }],
+        listItem: 'bullet',
+      },
+      {
+        _type: 'block',
+        _key: 'two',
+        markDefs: [],
+        level: 1,
+        children: [{ _type: 'span', marks: [], text: 'Two' }],
+        listItem: 'bullet',
+      },
+      {
+        _type: 'block',
+        _key: 'nested',
+        markDefs: [],
+        level: 2,
+        children: [{ _type: 'span', marks: [], text: 'Nested' }],
+        listItem: 'number',
+      },
+    ];
+
+    const result = await renderPortableText(
+      input,
+      {},
+      false,
+      LIST_NEST_MODE_DIRECT,
+    );
+
+    assertHTML(
+      result.container,
+      '<ul><li>One</li><li>Two</li><ol><li>Nested</li></ol></ul>',
+    );
+  });
+
+  test('passes isInline false to list and list item components', async () => {
+    @Component({
+      // eslint-disable-next-line @angular-eslint/component-selector
+      selector: 'ul',
+      template: '<ng-container #children />',
+      host: { '[attr.data-inline]': 'isInline()' },
+    })
+    class InlineStateListComponent extends PortableTextListComponent {}
+
+    @Component({
+      // eslint-disable-next-line @angular-eslint/component-selector
+      selector: 'li',
+      template: '<ng-container #children />',
+      host: { '[attr.data-inline]': 'isInline()' },
+    })
+    class InlineStateListItemComponent extends PortableTextListItemComponent {}
+
+    const input = [
+      {
+        _type: 'block',
+        _key: 'one',
+        markDefs: [],
+        level: 1,
+        children: [{ _type: 'span', marks: [], text: 'One' }],
+        listItem: 'bullet',
+      },
+      {
+        _type: 'block',
+        _key: 'two',
+        markDefs: [],
+        level: 1,
+        children: [{ _type: 'span', marks: [], text: 'Two' }],
+        listItem: 'bullet',
+      },
+      {
+        _type: 'block',
+        _key: 'nested',
+        markDefs: [],
+        level: 2,
+        children: [{ _type: 'span', marks: [], text: 'Nested' }],
+        listItem: 'number',
+      },
+    ];
+
+    const result = await renderPortableText(input, {
+      list: InlineStateListComponent,
+      listItem: InlineStateListItemComponent,
+    });
+
+    assertHTML(
+      result.container,
+      '<ul data-inline="false"><li data-inline="false">One</li><li data-inline="false">Two<ul data-inline="false"><li data-inline="false">Nested</li></ul></li></ul>',
+    );
+  });
+
   test('builds all basic marks as expected', async () => {
     const { input, output } = fixtures.allBasicMarks;
     const result = await renderPortableText(input);
@@ -122,6 +225,14 @@ describe('PortableTextComponent', () => {
     const { input, output } = fixtures.emptyArray;
     const result = await renderPortableText(input);
     assertHTML(result.container, output);
+  });
+
+  test('handles null or undefined values', async () => {
+    const { container, rerender } = await renderPortableText(null);
+    assertHTML(container, '');
+
+    await rerender({ inputs: { value: undefined } });
+    assertHTML(container, '');
   });
 
   test('handles lists without level', async () => {
@@ -202,6 +313,26 @@ describe('PortableTextComponent', () => {
     );
   });
 
+  test('can render all list styles with a single list component', async () => {
+    @Component({
+      // eslint-disable-next-line @angular-eslint/component-selector
+      selector: 'ul',
+      template: '<ng-container #children />',
+      host: { '[class]': '"single-list"' },
+    })
+    class SingleListComponent extends PortableTextListComponent {}
+
+    const { input } = fixtures.basicNumberedList;
+    const result = await renderPortableText(input, {
+      list: SingleListComponent,
+    });
+
+    assertHTML(
+      result.container,
+      '<p>Let&#x27;s test some of these lists!</p><ul class="single-list"><li>Number 1</li><li>Number 2</li><li>Number 3</li></ul>',
+    );
+  });
+
   test('can render custom list item styles with provided list style component', async () => {
     const { input } = fixtures.customListItemType;
     const result = await renderPortableText(input, {
@@ -237,6 +368,23 @@ describe('PortableTextComponent', () => {
     });
 
     assertHTML(result.container, output);
+  });
+
+  test('can render all block styles with a single block component', async () => {
+    @Component({
+      // eslint-disable-next-line @angular-eslint/component-selector
+      selector: 'p',
+      template: '<ng-container #children />',
+      host: { '[class]': '"single-block"' },
+    })
+    class SingleBlockComponent extends PortableTextBlockComponent {}
+
+    const { input } = fixtures.plainHeaderBlock;
+    const result = await renderPortableText(input, {
+      block: SingleBlockComponent,
+    });
+
+    assertHTML(result.container, '<p class="single-block">Dat heading</p>');
   });
 
   test('can specify custom component for custom block types with children', async () => {
@@ -369,5 +517,39 @@ describe('PortableTextComponent', () => {
       result.container,
       '<p><span class="unknown">Unknown (unknown-deco): simple</span><span class="unknown">Unknown (unknown-mark): advanced</span></p>',
     );
+  });
+
+  test('can override unknown type component', async () => {
+    @Component({
+      // eslint-disable-next-line @angular-eslint/component-selector
+      selector: 'div',
+      template: `Unknown type: {{ value()._type }}`,
+      host: { '[class]': '"unknown-type"' },
+    })
+    class CustomUnknownTypeComponent extends PortableTextTypeComponent {}
+
+    const input = {
+      _type: 'mystery',
+      _key: 'mystery',
+      text: 'No renderer',
+    };
+
+    const result = await renderPortableText(input, {
+      unknownType: CustomUnknownTypeComponent,
+    });
+
+    assertHTML(
+      result.container,
+      '<div class="unknown-type">Unknown type: mystery</div>',
+    );
+  });
+
+  test('does not mutate the input value', async () => {
+    const input = structuredClone(fixtures.nestedLists.input);
+    const original = structuredClone(input);
+
+    await renderPortableText(input);
+
+    expect(input).toEqual(original);
   });
 });

--- a/packages/sanity/portabletext/src/tests/to-plain-text.spec.ts
+++ b/packages/sanity/portabletext/src/tests/to-plain-text.spec.ts
@@ -1,0 +1,37 @@
+import { test } from 'vitest';
+
+import { toPlainText } from '../index';
+import * as fixtures from './fixtures';
+
+test('can extract text from all fixtures without crashing', ({ expect }) => {
+  for (const [key, fixture] of Object.entries(fixtures)) {
+    if (key === 'default' || !('input' in fixture)) {
+      continue;
+    }
+
+    const output = toPlainText(fixture.input);
+    expect(output).toBeTypeOf('string');
+  }
+});
+
+test('can extract text from a properly formatted block', ({ expect }) => {
+  const text = toPlainText([
+    {
+      _type: 'block',
+      markDefs: [{ _type: 'link', _key: 'a1b', href: 'https://some.url/' }],
+      children: [
+        { _type: 'span', text: 'Plain ' },
+        { _type: 'span', text: 'text', marks: ['em'] },
+        { _type: 'span', text: ', even with ' },
+        { _type: 'span', text: 'annotated value', marks: ['a1b'] },
+        { _type: 'span', text: '.' },
+      ],
+    },
+    {
+      _type: 'otherBlockType',
+      children: [{ _type: 'span', text: 'Should work?' }],
+    },
+  ]);
+
+  expect(text).toBe('Plain text, even with annotated value.\n\nShould work?');
+});

--- a/packages/sanity/portabletext/src/tests/typegen.spec.ts
+++ b/packages/sanity/portabletext/src/tests/typegen.spec.ts
@@ -1,0 +1,120 @@
+import { expectTypeOf, test } from 'vitest';
+import type {
+  PortableTextBlock,
+  PortableTextMarkDefinition,
+  PortableTextSpan,
+} from '@portabletext/types';
+
+import {
+  AngularPortableTextList,
+  InferComponents,
+  InferStrictComponents,
+  InferValue,
+  PortableTextBlockComponent,
+  PortableTextListComponent,
+  PortableTextListItemComponent,
+  PortableTextMarkComponent,
+  PortableTextProps,
+  PortableTextTypeComponent,
+} from '../index';
+
+interface ImageType {
+  _type: 'image';
+  asset: { _ref: string };
+}
+
+interface HighlightMark extends PortableTextMarkDefinition {
+  _type: 'highlight';
+  color: string;
+}
+
+interface LinkMark extends PortableTextMarkDefinition {
+  _type: 'link';
+  href: string;
+}
+
+type PostBlock = PortableTextBlock<
+  HighlightMark | LinkMark,
+  PortableTextSpan,
+  'normal' | 'callout',
+  'bullet' | 'checklist'
+> & { _type: 'block' };
+
+type CalloutBlock = Omit<PostBlock, 'style'> & { style?: 'callout' };
+type ChecklistList = AngularPortableTextList extends infer List
+  ? List extends AngularPortableTextList
+    ? Omit<List, 'listItem'> & { listItem: 'checklist' }
+    : never
+  : never;
+type BulletListItem = Omit<PostBlock, 'listItem'> & { listItem: 'bullet' };
+type ChecklistListItem = Omit<PostBlock, 'listItem'> & {
+  listItem: 'checklist';
+};
+type AnyListItem = Omit<PostBlock, 'listItem'> & {
+  listItem: 'bullet' | 'checklist';
+};
+
+type PostContent = (PostBlock | ImageType)[];
+
+class ImageComponent extends PortableTextTypeComponent<ImageType> {}
+class HighlightComponent extends PortableTextMarkComponent<HighlightMark> {}
+class CalloutBlockComponent extends PortableTextBlockComponent<CalloutBlock> {}
+class ChecklistComponent extends PortableTextListComponent<ChecklistList> {}
+class AnyListItemComponent extends PortableTextListItemComponent<AnyListItem> {}
+class BulletListItemComponent extends PortableTextListItemComponent<BulletListItem> {}
+class ChecklistListItemComponent extends PortableTextListItemComponent<ChecklistListItem> {}
+
+test('infers portable text values from query result shapes', () => {
+  type InferredValue = InferValue<{ content: PostContent | null }>;
+
+  expectTypeOf<InferredValue>().toEqualTypeOf<PostContent>();
+});
+
+test('infers component maps from portable text values', () => {
+  const components = {
+    types: { image: ImageComponent },
+    marks: { highlight: HighlightComponent },
+    block: { callout: CalloutBlockComponent },
+    list: { checklist: ChecklistComponent },
+    listItem: AnyListItemComponent,
+  } satisfies InferComponents<PostContent>;
+
+  expectTypeOf(components).toBeObject();
+});
+
+test('strict component maps require all custom handlers', () => {
+  const components = {
+    types: { image: ImageComponent },
+    marks: { highlight: HighlightComponent },
+    block: { callout: CalloutBlockComponent },
+    list: { checklist: ChecklistComponent },
+    listItem: {
+      bullet: BulletListItemComponent,
+      checklist: ChecklistListItemComponent,
+    },
+  } satisfies InferStrictComponents<PostContent>;
+
+  expectTypeOf(components).toBeObject();
+});
+
+test('strict component maps reject missing custom handlers', () => {
+  const components = {
+    // @ts-expect-error image handler is required by strict components
+    types: {},
+    marks: { highlight: HighlightComponent },
+    block: { callout: CalloutBlockComponent },
+    list: { checklist: ChecklistComponent },
+    listItem: {
+      bullet: BulletListItemComponent,
+      checklist: ChecklistListItemComponent,
+    },
+  } satisfies InferStrictComponents<PostContent>;
+
+  expectTypeOf(components).toBeObject();
+});
+
+test('portable text props accept null and undefined values', () => {
+  expectTypeOf<PortableTextProps<PostBlock>['value']>().toEqualTypeOf<
+    PostBlock | PostBlock[] | null | undefined
+  >();
+});

--- a/packages/sanity/portabletext/src/types.ts
+++ b/packages/sanity/portabletext/src/types.ts
@@ -1,12 +1,17 @@
 import type { Type } from '@angular/core';
 import type {
+  ArbitraryTypedObject,
   PortableTextBlock,
   PortableTextBlockStyle,
   PortableTextListItemBlock,
   PortableTextListItemType,
   TypedObject,
 } from '@portabletext/types';
-import type { ToolkitPortableTextList } from '@portabletext/toolkit';
+import type {
+  ToolkitListNestMode,
+  ToolkitPortableTextList,
+  ToolkitPortableTextListItem,
+} from '@portabletext/toolkit';
 import {
   PortableTextTypeComponent,
   PortableTextMarkComponent,
@@ -15,25 +20,36 @@ import {
   PortableTextListComponent,
 } from './directives/portable-text-directives';
 
-export interface PortableTextComponents {
-  types?: Record<string, Type<PortableTextTypeComponent>>;
-  marks?: Record<string, Type<PortableTextMarkComponent> | undefined>;
-  block?: Partial<
-    Record<PortableTextBlockStyle, Type<PortableTextBlockComponent> | undefined>
-  >;
-  list?: Partial<
-    Record<PortableTextListItemType, Type<PortableTextListComponent>>
-  >;
-  listItem?:
-    | Partial<
-        Record<PortableTextListItemType, Type<PortableTextListItemComponent>>
-      >
-    | Type<PortableTextListItemComponent>;
-  hardBreak?: Type<unknown> | false;
-  unknownMark?: Type<PortableTextMarkComponent>;
-  unknownBlockStyle?: Type<PortableTextBlockComponent>;
-  unknownList?: Type<PortableTextListComponent>;
-  unknownListItem?: Type<PortableTextListItemComponent>;
+/**
+ * Properties for the Portable Text Angular component.
+ *
+ * @template B Types that can appear in the array of blocks.
+ */
+export interface PortableTextProps<
+  B extends TypedObject = PortableTextBlock | ArbitraryTypedObject,
+> {
+  /**
+   * One or more blocks to render.
+   */
+  value: B | B[] | null | undefined;
+
+  /**
+   * Angular components to use for rendering.
+   */
+  components?: PortableTextComponents<B>;
+
+  /**
+   * Function to call when encountering unknown types, marks, block styles,
+   * list styles, or list item styles. Prints a warning by default.
+   * Pass `false` to disable.
+   */
+  onMissingComponent?: MissingComponentHandler | false;
+
+  /**
+   * Determines whether lists are nested inside list items (`html`) or as a
+   * direct child of another list (`direct`).
+   */
+  listNestingMode?: ToolkitListNestMode;
 }
 
 /**
@@ -43,6 +59,463 @@ export interface PortableTextComponents {
 export type UnknownNodeType =
   | { [key: string]: unknown; _type: string }
   | TypedObject;
+
+// Angular component classes are invariant through signal inputs, so open
+// component maps need a deliberate escape hatch just like @portabletext/react.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyTypedObject = any;
+
+export type PortableTextAngularComponent<
+  N extends TypedObject = AnyTypedObject,
+> = Type<PortableTextTypeComponent<N>>;
+
+export type PortableTextBlockComponentType<
+  N extends TypedObject = PortableTextBlock,
+> = Type<PortableTextBlockComponent<N>>;
+
+export type PortableTextListComponentType<
+  N extends TypedObject = AngularPortableTextList,
+> = Type<PortableTextListComponent<N>>;
+
+export type PortableTextListItemComponentType<
+  N extends TypedObject = PortableTextListItemBlock,
+> = Type<PortableTextListItemComponent<N>>;
+
+export type PortableTextMarkComponentType<
+  M extends TypedObject = AnyTypedObject,
+> = Type<PortableTextMarkComponent<M>>;
+
+type LooseRecord<K extends string, V> = Record<string, V> & {
+  [P in K]?: V;
+};
+
+type TypeName<T> = T extends { _type: infer Name }
+  ? Name extends string
+    ? Name
+    : never
+  : never;
+
+type BuiltInPortableTextString<T> = T extends string
+  ? string extends T
+    ? never
+    : T
+  : never;
+
+type CustomPortableTextType<B extends TypedObject> = Exclude<
+  B,
+  { _type: 'block' }
+>;
+
+type CustomPortableTextTypeName<B extends TypedObject> = TypeName<
+  CustomPortableTextType<B>
+>;
+
+type PortableTextBlockType<B extends TypedObject> = Extract<
+  B,
+  { _type: 'block' }
+>;
+
+export type DefaultPortableTextBlockStyle =
+  BuiltInPortableTextString<PortableTextBlockStyle>;
+
+type PortableTextBlockStyleName<B extends TypedObject> =
+  PortableTextBlockType<B> extends { style?: infer Style }
+    ? NonNullable<Style> extends string
+      ? NonNullable<Style>
+      : never
+    : never;
+
+type CustomPortableTextBlockStyleName<B extends TypedObject> = Exclude<
+  PortableTextBlockStyleName<B>,
+  DefaultPortableTextBlockStyle
+>;
+
+type PortableTextBlockForStyle<B extends TypedObject, Style extends string> =
+  PortableTextBlockType<B> extends infer Block
+    ? Block extends TypedObject
+      ? Omit<Block, 'style'> & {
+          style?: Extract<Block extends { style?: infer S } ? S : never, Style>;
+        }
+      : never
+    : never;
+
+type PortableTextBlockComponentFor<B extends TypedObject> =
+  PortableTextBlockType<B> extends never
+    ? PortableTextBlockComponentType
+    : PortableTextAngularComponent<PortableTextBlockType<B>>;
+
+type PortableTextBlockComponents<B extends TypedObject> =
+  string extends PortableTextBlockStyleName<B>
+    ? LooseRecord<
+        PortableTextBlockStyle,
+        PortableTextBlockComponentType | undefined
+      >
+    : PortableTextBlockStyleName<B> extends never
+      ? LooseRecord<
+          PortableTextBlockStyle,
+          PortableTextBlockComponentType | undefined
+        >
+      : Record<
+          string,
+          PortableTextAngularComponent<AnyTypedObject> | undefined
+        > & {
+          [Style in PortableTextBlockStyleName<B>]?: PortableTextAngularComponent<
+            PortableTextBlockForStyle<B, Style>
+          >;
+        };
+
+type PortableTextListItemName<B extends TypedObject> =
+  PortableTextBlockType<B> extends { listItem?: infer ListItem }
+    ? NonNullable<ListItem> extends string
+      ? NonNullable<ListItem>
+      : never
+    : never;
+
+export type DefaultPortableTextListItem =
+  BuiltInPortableTextString<PortableTextListItemType>;
+
+type CustomPortableTextListItemName<B extends TypedObject> = Exclude<
+  PortableTextListItemName<B>,
+  DefaultPortableTextListItem
+>;
+
+type PortableTextListForItem<ListItem extends string> =
+  AngularPortableTextList extends infer List
+    ? List extends AngularPortableTextList
+      ? Omit<List, 'listItem'> & { listItem: ListItem }
+      : never
+    : never;
+
+type PortableTextBlockForListItem<
+  B extends TypedObject,
+  ListItem extends string,
+> =
+  PortableTextBlockType<B> extends infer Block
+    ? Block extends TypedObject
+      ? Omit<Block, 'listItem'> & {
+          listItem: Extract<
+            Block extends { listItem?: infer Item } ? Item : never,
+            ListItem
+          >;
+        }
+      : never
+    : never;
+
+type PortableTextListComponentFor<B extends TypedObject> =
+  PortableTextListItemName<B> extends never
+    ? PortableTextListComponentType
+    : PortableTextAngularComponent<
+        PortableTextListForItem<PortableTextListItemName<B>>
+      >;
+
+type PortableTextListItemComponentFor<B extends TypedObject> =
+  PortableTextListItemName<B> extends never
+    ? PortableTextListItemComponentType
+    : PortableTextAngularComponent<
+        PortableTextBlockForListItem<B, PortableTextListItemName<B>>
+      >;
+
+type PortableTextListComponents<B extends TypedObject> =
+  string extends PortableTextListItemName<B>
+    ? LooseRecord<
+        PortableTextListItemType,
+        PortableTextListComponentType | undefined
+      >
+    : PortableTextListItemName<B> extends never
+      ? Record<string, PortableTextAngularComponent<AnyTypedObject> | undefined>
+      : Record<
+          string,
+          PortableTextAngularComponent<AnyTypedObject> | undefined
+        > & {
+          [ListItem in PortableTextListItemName<B>]?: PortableTextAngularComponent<
+            PortableTextListForItem<ListItem>
+          >;
+        };
+
+type PortableTextListItemComponents<B extends TypedObject> =
+  string extends PortableTextListItemName<B>
+    ? LooseRecord<
+        PortableTextListItemType,
+        PortableTextListItemComponentType | undefined
+      >
+    : PortableTextListItemName<B> extends never
+      ? Record<string, PortableTextAngularComponent<AnyTypedObject> | undefined>
+      : Record<
+          string,
+          PortableTextAngularComponent<AnyTypedObject> | undefined
+        > & {
+          [ListItem in PortableTextListItemName<B>]?: PortableTextAngularComponent<
+            PortableTextBlockForListItem<B, ListItem>
+          >;
+        };
+
+type PortableTextMarkType<B extends TypedObject> =
+  PortableTextBlockType<B> extends { markDefs?: infer MarkDefs }
+    ? NonNullable<MarkDefs> extends readonly (infer MarkDef)[]
+      ? Extract<MarkDef, TypedObject>
+      : never
+    : never;
+
+type PortableTextMarkTypeName<B extends TypedObject> = TypeName<
+  PortableTextMarkType<B>
+>;
+
+export type DefaultPortableTextMark =
+  | 'em'
+  | 'strong'
+  | 'code'
+  | 'underline'
+  | 'strike-through'
+  | 'link';
+
+type CustomPortableTextMarkTypeName<B extends TypedObject> = Exclude<
+  PortableTextMarkTypeName<B>,
+  DefaultPortableTextMark
+>;
+
+type PortableTextMarkComponents<B extends TypedObject> =
+  string extends PortableTextMarkTypeName<B>
+    ? Record<string, PortableTextMarkComponentType<AnyTypedObject> | undefined>
+    : PortableTextMarkTypeName<B> extends never
+      ? Record<
+          string,
+          PortableTextMarkComponentType<AnyTypedObject> | undefined
+        >
+      : Record<
+          string,
+          PortableTextMarkComponentType<AnyTypedObject> | undefined
+        > & {
+          [Type in PortableTextMarkTypeName<B>]?: PortableTextMarkComponentType<
+            Extract<PortableTextMarkType<B>, { _type: Type }>
+          >;
+        };
+
+type PortableTextTypeComponents<B extends TypedObject> =
+  string extends CustomPortableTextTypeName<B>
+    ? Record<string, PortableTextAngularComponent<AnyTypedObject> | undefined>
+    : CustomPortableTextTypeName<B> extends never
+      ? Record<string, PortableTextAngularComponent<AnyTypedObject> | undefined>
+      : Record<
+          string,
+          PortableTextAngularComponent<AnyTypedObject> | undefined
+        > & {
+          [Type in CustomPortableTextTypeName<B>]?: PortableTextAngularComponent<
+            Extract<CustomPortableTextType<B>, { _type: Type }>
+          >;
+        };
+
+type PortableTextValueItem<T> = Extract<
+  NonNullable<T> extends readonly (infer B)[] ? B : NonNullable<T>,
+  TypedObject
+>;
+
+type PortableTextArrayItem<T> =
+  NonNullable<T> extends readonly (infer Item)[]
+    ? Extract<NonNullable<Item>, { _type: 'block' }> extends never
+      ? never
+      : Extract<NonNullable<Item>, TypedObject>
+    : never;
+
+type InferPortableTextTypedObject<T> = T extends unknown
+  ? PortableTextArrayItem<T> extends never
+    ? NonNullable<T> extends readonly (infer Item)[]
+      ? InferPortableTextTypedObject<Item>
+      : NonNullable<T> extends object
+        ? {
+            [Key in keyof NonNullable<T>]: InferPortableTextTypedObject<
+              NonNullable<T>[Key]
+            >;
+          }[keyof NonNullable<T>]
+        : never
+    : PortableTextArrayItem<T>
+  : never;
+
+type StrictPortableTextTypeComponents<B extends TypedObject> =
+  string extends CustomPortableTextTypeName<B>
+    ? Record<string, PortableTextAngularComponent | undefined>
+    : CustomPortableTextTypeName<B> extends never
+      ? Record<string, never>
+      : {
+          [Type in CustomPortableTextTypeName<B>]-?: PortableTextAngularComponent<
+            Extract<CustomPortableTextType<B>, { _type: Type }>
+          >;
+        };
+
+type StrictPortableTextTypeComponentOverrides<B extends TypedObject> =
+  CustomPortableTextTypeName<B> extends never
+    ? { types?: StrictPortableTextTypeComponents<B> }
+    : { types: StrictPortableTextTypeComponents<B> };
+
+type StrictPortableTextMarkComponents<B extends TypedObject> =
+  string extends PortableTextMarkTypeName<B>
+    ? Record<string, PortableTextMarkComponentType | undefined>
+    : PortableTextMarkTypeName<B> extends never
+      ? Record<string, never>
+      : {
+          [Type in CustomPortableTextMarkTypeName<B>]-?: PortableTextMarkComponentType<
+            Extract<PortableTextMarkType<B>, { _type: Type }>
+          >;
+        } & {
+          [Type in Extract<
+            DefaultPortableTextMark,
+            PortableTextMarkTypeName<B>
+          >]?: PortableTextMarkComponentType<
+            Extract<PortableTextMarkType<B>, { _type: Type }>
+          >;
+        };
+
+type StrictPortableTextMarkComponentOverrides<B extends TypedObject> =
+  CustomPortableTextMarkTypeName<B> extends never
+    ? { marks?: StrictPortableTextMarkComponents<B> }
+    : { marks: StrictPortableTextMarkComponents<B> };
+
+type StrictPortableTextBlockComponents<B extends TypedObject> =
+  string extends PortableTextBlockStyleName<B>
+    ? LooseRecord<
+        PortableTextBlockStyle,
+        PortableTextBlockComponentType | undefined
+      >
+    : PortableTextBlockStyleName<B> extends never
+      ? Record<string, never>
+      : {
+          [Style in CustomPortableTextBlockStyleName<B>]-?: PortableTextAngularComponent<
+            PortableTextBlockForStyle<B, Style>
+          >;
+        } & {
+          [Style in Extract<
+            DefaultPortableTextBlockStyle,
+            PortableTextBlockStyleName<B>
+          >]?: PortableTextAngularComponent<
+            PortableTextBlockForStyle<B, Style>
+          >;
+        };
+
+type StrictPortableTextBlockComponentOverrides<B extends TypedObject> =
+  CustomPortableTextBlockStyleName<B> extends never
+    ? {
+        block?:
+          | StrictPortableTextBlockComponents<B>
+          | PortableTextBlockComponentFor<B>;
+      }
+    : {
+        block:
+          | StrictPortableTextBlockComponents<B>
+          | PortableTextBlockComponentFor<B>;
+      };
+
+type StrictPortableTextListComponents<B extends TypedObject> =
+  string extends PortableTextListItemName<B>
+    ? LooseRecord<
+        PortableTextListItemType,
+        PortableTextListComponentType | undefined
+      >
+    : PortableTextListItemName<B> extends never
+      ? Record<string, never>
+      : {
+          [ListItem in CustomPortableTextListItemName<B>]-?: PortableTextAngularComponent<
+            PortableTextListForItem<ListItem>
+          >;
+        } & {
+          [ListItem in Extract<
+            DefaultPortableTextListItem,
+            PortableTextListItemName<B>
+          >]?: PortableTextAngularComponent<PortableTextListForItem<ListItem>>;
+        };
+
+type StrictPortableTextListComponentOverrides<B extends TypedObject> =
+  CustomPortableTextListItemName<B> extends never
+    ? {
+        list?:
+          | StrictPortableTextListComponents<B>
+          | PortableTextListComponentFor<B>;
+      }
+    : {
+        list:
+          | StrictPortableTextListComponents<B>
+          | PortableTextListComponentFor<B>;
+      };
+
+type StrictPortableTextListItemComponents<B extends TypedObject> =
+  string extends PortableTextListItemName<B>
+    ? LooseRecord<
+        PortableTextListItemType,
+        PortableTextListItemComponentType | undefined
+      >
+    : PortableTextListItemName<B> extends never
+      ? Record<string, never>
+      : {
+          [ListItem in PortableTextListItemName<B>]-?: PortableTextAngularComponent<
+            PortableTextBlockForListItem<B, ListItem>
+          >;
+        };
+
+type StrictPortableTextListItemComponentOverrides<B extends TypedObject> = {
+  listItem?:
+    | StrictPortableTextListItemComponents<B>
+    | PortableTextListItemComponentFor<B>;
+};
+
+/**
+ * Object defining Angular component overrides for Portable Text rendering.
+ */
+export interface PortableTextComponents<
+  B extends TypedObject = AnyTypedObject,
+> {
+  types?: PortableTextTypeComponents<B>;
+  marks?: PortableTextMarkComponents<B>;
+  block?: PortableTextBlockComponents<B> | PortableTextBlockComponentFor<B>;
+  list?: PortableTextListComponents<B> | PortableTextListComponentFor<B>;
+  listItem?:
+    | PortableTextListItemComponents<B>
+    | PortableTextListItemComponentFor<B>;
+  hardBreak?: Type<unknown> | false;
+  unknownMark?: PortableTextMarkComponentType;
+  unknownType?: PortableTextAngularComponent<UnknownNodeType>;
+  unknownBlockStyle?: PortableTextBlockComponentType;
+  unknownList?: PortableTextListComponentType<AngularPortableTextList>;
+  unknownListItem?: PortableTextListItemComponentType<PortableTextListItemBlock>;
+}
+
+export type InferComponents<T> = PortableTextComponents<
+  PortableTextValueItem<T>
+>;
+
+export type InferValue<T> = Exclude<
+  InferPortableTextTypedObject<T>,
+  undefined
+>[];
+
+export type InferStrictComponents<T> = Omit<
+  PortableTextComponents<PortableTextValueItem<T>>,
+  'types' | 'marks' | 'block' | 'list' | 'listItem'
+> &
+  StrictPortableTextTypeComponentOverrides<PortableTextValueItem<T>> &
+  StrictPortableTextMarkComponentOverrides<PortableTextValueItem<T>> &
+  StrictPortableTextBlockComponentOverrides<PortableTextValueItem<T>> &
+  StrictPortableTextListComponentOverrides<PortableTextValueItem<T>> &
+  StrictPortableTextListItemComponentOverrides<PortableTextValueItem<T>>;
+
+/**
+ * Object defining the different Angular components to use for rendering
+ * Portable Text and user-provided types.
+ */
+export interface PortableTextAngularComponents<
+  B extends TypedObject = AnyTypedObject,
+> {
+  types: PortableTextTypeComponents<B>;
+  marks: PortableTextMarkComponents<B>;
+  block: PortableTextBlockComponents<B> | PortableTextBlockComponentFor<B>;
+  list: PortableTextListComponents<B> | PortableTextListComponentFor<B>;
+  listItem:
+    | PortableTextListItemComponents<B>
+    | PortableTextListItemComponentFor<B>;
+  hardBreak: Type<unknown> | false;
+  unknownMark: PortableTextMarkComponentType;
+  unknownType: PortableTextAngularComponent<UnknownNodeType>;
+  unknownBlockStyle: PortableTextBlockComponentType;
+  unknownList: PortableTextListComponentType<AngularPortableTextList>;
+  unknownListItem: PortableTextListItemComponentType<PortableTextListItemBlock>;
+}
 
 export type NodeType =
   | 'block'
@@ -63,9 +536,10 @@ export interface Serializable<T> {
 }
 
 export interface SerializedBlock {
-  _key?: string;
+  _key: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   children: any[];
+  index: number;
   isInline: boolean;
   node: PortableTextBlock | PortableTextListItemBlock;
 }
@@ -98,4 +572,12 @@ export interface TemplateContext<Node extends TypedObject> {
  * A virtual "list" node for Portable Text - not strictly part of Portable Text,
  * but generated by this library to ease the rendering of lists in HTML etc
  */
-export type PortableTextListBlock = ToolkitPortableTextList;
+export type AngularPortableTextList = ToolkitPortableTextList;
+
+export type PortableTextListBlock = AngularPortableTextList;
+
+/**
+ * A virtual "list item" node for Portable Text - not strictly any different
+ * from a regular Portable Text Block, but guaranteed to have a `listItem`.
+ */
+export type AngularPortableTextListItem = ToolkitPortableTextListItem;

--- a/packages/sanity/portabletext/src/utils.ts
+++ b/packages/sanity/portabletext/src/utils.ts
@@ -16,6 +16,7 @@ export function serializeBlock(
   return {
     _key: trackBy(node._key, index, 'block'),
     children,
+    index,
     isInline,
     node,
   };

--- a/packages/sanity/portabletext/src/utils/merge.ts
+++ b/packages/sanity/portabletext/src/utils/merge.ts
@@ -1,9 +1,12 @@
-import type { PortableTextComponents } from '../types';
+import type {
+  PortableTextAngularComponents,
+  PortableTextComponents,
+} from '../types';
 
 export function mergeComponents(
-  parent: PortableTextComponents,
-  overrides: Partial<PortableTextComponents>,
-): Required<PortableTextComponents> {
+  parent: PortableTextAngularComponents,
+  overrides: PortableTextComponents,
+): PortableTextAngularComponents {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { block, list, listItem, marks, types, ...rest } = overrides;
   return {
@@ -14,21 +17,21 @@ export function mergeComponents(
     marks: mergeDeeply(parent, overrides, 'marks'),
     types: mergeDeeply(parent, overrides, 'types'),
     ...rest,
-  } as Required<PortableTextComponents>;
+  } as PortableTextAngularComponents;
 }
 
 function mergeDeeply<
   T extends 'block' | 'list' | 'listItem' | 'marks' | 'types',
 >(
-  parent: PortableTextComponents,
-  overrides: Partial<PortableTextComponents>,
+  parent: PortableTextAngularComponents,
+  overrides: PortableTextComponents,
   key: T,
-): PortableTextComponents[T] {
+): PortableTextAngularComponents[T] {
   const override = overrides[key];
   const parentVal = parent[key];
 
   if (typeof override === 'function') {
-    return override as PortableTextComponents[T];
+    return override as PortableTextAngularComponents[T];
   }
 
   if (override && typeof parentVal === 'function') {
@@ -36,7 +39,7 @@ function mergeDeeply<
   }
 
   if (override) {
-    return { ...parentVal, ...override };
+    return { ...parentVal, ...override } as PortableTextAngularComponents[T];
   }
 
   return parentVal;


### PR DESCRIPTION
## PR Checklist

Current behavior: the Angular portabletext renderer was based on older `@portabletext/react` behavior and was missing the v6.2.0 public API/runtime parity added upstream.

Closes: N/A

## What is the new behavior?

- Aligns the Angular portabletext renderer with `@portabletext/react` v6.2.0 behavior where it maps cleanly to Angular.
- Adds nullable value handling, `listNestingMode`, `defaultComponents`/`mergeComponents` exports, the `PortableText` alias, `unknownType` fallback support, `renderNode`/`index` props, and function-style `block`/`list`/`listItem` renderers.
- Expands parity coverage for direct list nesting, unknown type overrides, mutation safety, list/list-item prop semantics, and `toPlainText`.
- Updates portabletext docs and package credits to reference `@portabletext/react` v6.2.0.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Existing Angular inputs and component override shapes remain supported. New renderer props are supplied internally, and `index` defaults to `0` for direct component usage.

## Other information

Verified with:

- `pnpm --filter @limitless-angular/sanity lint`
- `pnpm --filter @limitless-angular/sanity exec tsc -p tsconfig.lib.json --noEmit`
- `pnpm --filter @limitless-angular/sanity test`
- `pnpm --filter @limitless-angular/sanity build`

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?