### PR TITLE
feat(release): support next prereleases

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -7,6 +7,11 @@ on:
         description: 'Version to publish (optional - will use conventional commits if not specified)'
         required: false
         default: ''
+      prerelease:
+        description: 'Infer or coerce the release as a next prerelease'
+        required: false
+        default: false
+        type: boolean
       verbose:
         description: 'Enable verbose logging'
         required: false
@@ -74,10 +79,14 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
           RELEASE_VERBOSE: ${{ inputs.verbose }}
           RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_PRERELEASE: ${{ inputs.prerelease }}
         run: |
           ARGS=()
           if [ -n "$RELEASE_VERSION" ]; then
             ARGS+=(--version "$RELEASE_VERSION")
+          fi
+          if [ "$RELEASE_PRERELEASE" = "true" ]; then
+            ARGS+=(--prerelease)
           fi
           if [ "$RELEASE_VERBOSE" = "true" ]; then
             ARGS+=(--verbose)
@@ -89,7 +98,9 @@ jobs:
         if: always()
         env:
           RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_PRERELEASE: ${{ inputs.prerelease }}
         run: |
           echo "## Release Process Summary" > "$GITHUB_STEP_SUMMARY"
           echo "- Mode: publish" >> "$GITHUB_STEP_SUMMARY"
           echo "- Version input: ${RELEASE_VERSION:-conventional commits}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Prerelease: ${RELEASE_PRERELEASE}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -7,6 +7,11 @@ on:
         description: 'Version to validate (optional - will use conventional commits if not specified)'
         required: false
         default: ''
+      prerelease:
+        description: 'Infer or coerce the release as a next prerelease'
+        required: false
+        default: false
+        type: boolean
       verbose:
         description: 'Enable verbose logging'
         required: false
@@ -64,10 +69,14 @@ jobs:
         env:
           RELEASE_VERBOSE: ${{ inputs.verbose }}
           RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_PRERELEASE: ${{ inputs.prerelease }}
         run: |
           ARGS=()
           if [ -n "$RELEASE_VERSION" ]; then
             ARGS+=(--version "$RELEASE_VERSION")
+          fi
+          if [ "$RELEASE_PRERELEASE" = "true" ]; then
+            ARGS+=(--prerelease)
           fi
           if [ "$RELEASE_VERBOSE" = "true" ]; then
             ARGS+=(--verbose)
@@ -79,7 +88,9 @@ jobs:
         if: always()
         env:
           RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_PRERELEASE: ${{ inputs.prerelease }}
         run: |
           echo "## Release Dry Run Summary" > "$GITHUB_STEP_SUMMARY"
           echo "- Mode: dry-run" >> "$GITHUB_STEP_SUMMARY"
           echo "- Version input: ${RELEASE_VERSION:-conventional commits}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Prerelease: ${RELEASE_PRERELEASE}" >> "$GITHUB_STEP_SUMMARY"

--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -11,19 +11,27 @@ Plan a release without changing files:
 ```bash
 pnpm run release:plan --version patch
 pnpm run release:plan --version 19.3.0 --json
+pnpm run release:plan --prerelease
 ```
 
 Validate a prospective release without publishing:
 
 ```bash
 pnpm run release:dry-run --version patch
+pnpm run release:dry-run --prerelease
 ```
 
 Publish a release:
 
 ```bash
 pnpm turbo run release:publish --filter=@limitless-angular/release-tools -- --version patch
+pnpm turbo run release:publish --filter=@limitless-angular/release-tools -- --prerelease
 ```
+
+Prerelease mode infers the release level from conventional commits and uses the
+`next` prerelease identifier. For example, a feature-level release from
+`19.2.0` becomes `19.3.0-next.0`; the next prerelease in that train becomes
+`19.3.0-next.1`.
 
 ## Pipeline
 
@@ -39,6 +47,10 @@ Both dry-run and publish mode use the same release pipeline:
 7. Test the same artifact with `compat:test`.
 8. In publish mode only, commit, tag, publish the tarball to npm, push the
    release commit and tag, and create the GitHub release.
+
+Prerelease versions are published to npm with the `next` dist-tag and their
+GitHub releases are marked as prereleases. Stable versions use npm's `latest`
+dist-tag.
 
 Dry-run mode restores `packages/sanity/package.json` and
 `packages/sanity/CHANGELOG.md` after validation. The packed tarball remains under

--- a/tools/release/cli.mjs
+++ b/tools/release/cli.mjs
@@ -25,6 +25,7 @@ export function runCli(args = hideBin(process.argv)) {
         }),
       (argv) => {
         const plan = createReleasePlan({
+          prerelease: argv.prerelease,
           versionSpecifier: argv.version,
         });
 
@@ -49,6 +50,7 @@ export function runCli(args = hideBin(process.argv)) {
       (argv) =>
         runReleasePipeline({
           mode: argv.mode,
+          prerelease: argv.prerelease,
           verbose: argv.verbose,
           versionSpecifier: argv.version,
         }),
@@ -60,6 +62,7 @@ export function runCli(args = hideBin(process.argv)) {
       (argv) =>
         runReleasePipeline({
           mode: releaseModes.dryRun,
+          prerelease: argv.prerelease,
           verbose: argv.verbose,
           versionSpecifier: argv.version,
         }),
@@ -71,6 +74,7 @@ export function runCli(args = hideBin(process.argv)) {
       (argv) =>
         runReleasePipeline({
           mode: releaseModes.publish,
+          prerelease: argv.prerelease,
           verbose: argv.verbose,
           versionSpecifier: argv.version,
         }),
@@ -91,11 +95,18 @@ function addPipelineOptions(command) {
 }
 
 function addVersionOption(command) {
-  return command.option('version', {
-    describe:
-      'Explicit semver version or semver increment to release, such as 19.3.0, patch, minor, or major.',
-    type: 'string',
-  });
+  return command
+    .option('version', {
+      describe:
+        'Explicit semver version or semver increment to release, such as 19.3.0, patch, minor, or major.',
+      type: 'string',
+    })
+    .option('prerelease', {
+      default: false,
+      describe:
+        'Infer or coerce the planned version to a next prerelease, such as 19.3.0-next.0.',
+      type: 'boolean',
+    });
 }
 
 if (

--- a/tools/release/src/pipeline.mjs
+++ b/tools/release/src/pipeline.mjs
@@ -68,6 +68,7 @@ export function runReleasePipeline(options = {}) {
     capture: commandCapture,
     now: options.now,
     paths: options.paths,
+    prerelease: options.prerelease,
     versionSpecifier: options.versionSpecifier,
   });
   let snapshot;
@@ -88,7 +89,10 @@ export function runReleasePipeline(options = {}) {
     if (mode === releaseModes.publish) {
       publishSideEffectsStarted = true;
       commitRelease(plan, { run: commandRun });
-      publishTarball(artifact.tarballPath, { run: commandRun });
+      publishTarball(artifact.tarballPath, {
+        npmDistTag: plan.npmDistTag,
+        run: commandRun,
+      });
       pushRelease({ run: commandRun });
       createGitHubRelease(plan, { env: options.env, run: commandRun });
     }

--- a/tools/release/src/pipeline.test.mjs
+++ b/tools/release/src/pipeline.test.mjs
@@ -106,6 +106,61 @@ test('publish mode validates before starting release side effects', () => {
   }
 });
 
+test('publish mode tags npm and GitHub prereleases', () => {
+  const fixture = createReleaseFixture();
+  const commands = [];
+
+  try {
+    const result = runReleasePipeline({
+      artifact: {
+        readTarballPackageJson() {
+          return {
+            name: '@limitless-angular/sanity',
+            version: '1.1.0-next.0',
+          };
+        },
+        tarballPath: '/tmp/release.tgz',
+      },
+      capture: createCapture({
+        gitLog:
+          'abc1234\x01feat(sanity): add release validation\x01\x01Alfonso\x02',
+      }),
+      env: { GITHUB_TOKEN: 'token' },
+      mode: releaseModes.publish,
+      now: new Date('2026-06-08T00:00:00.000Z'),
+      paths: fixture.paths,
+      prerelease: true,
+      run: recordCommand(commands),
+    });
+
+    assert.equal(result.published, true);
+    assert.equal(result.plan.nextVersion, '1.1.0-next.0');
+    assert.equal(result.plan.npmDistTag, 'next');
+
+    const npmPublish = commands.find(
+      ({ command, args }) => command === 'npm' && args[0] === 'publish',
+    );
+    assert.deepEqual(npmPublish?.args, [
+      'publish',
+      '/tmp/release.tgz',
+      '--access',
+      'public',
+      '--registry',
+      'https://registry.npmjs.org',
+      '--tag',
+      'next',
+    ]);
+
+    const githubRelease = commands.find(
+      ({ command, args }) =>
+        command === 'gh' && args[0] === 'release' && args[1] === 'create',
+    );
+    assert.ok(githubRelease?.args.includes('--prerelease'));
+  } finally {
+    fixture.cleanup();
+  }
+});
+
 test('artifact version mismatch fails before publish side effects', () => {
   const fixture = createReleaseFixture();
   const commands = [];
@@ -159,14 +214,14 @@ function createReleaseFixture() {
   };
 }
 
-function createCapture() {
+function createCapture({ gitLog = '' } = {}) {
   return (command, args) => {
     if (command === 'git' && args[0] === 'rev-parse') {
       return '';
     }
 
     if (command === 'git' && args[0] === 'log') {
-      return '';
+      return gitLog;
     }
 
     throw new Error(`Unexpected command: ${command} ${args.join(' ')}`);

--- a/tools/release/src/plan.mjs
+++ b/tools/release/src/plan.mjs
@@ -9,6 +9,10 @@ import {
 import { capture as defaultCapture } from './commands.mjs';
 import { readJson } from './files.mjs';
 
+const prereleaseIdentifier = 'next';
+const prereleaseNpmDistTag = 'next';
+const stableNpmDistTag = 'latest';
+
 export function createReleasePlan(options = {}) {
   const paths = resolveReleasePaths(options.paths);
   const commandCapture = options.capture ?? defaultCapture;
@@ -20,8 +24,12 @@ export function createReleasePlan(options = {}) {
   });
   const commits = getCommitsSince(latestTag, { capture: commandCapture });
   const nextVersion = options.versionSpecifier
-    ? resolveVersionSpecifier(currentVersion, options.versionSpecifier)
-    : inferVersionFromCommits(currentVersion, commits);
+    ? resolveVersionSpecifier(currentVersion, options.versionSpecifier, {
+        prerelease: options.prerelease,
+      })
+    : inferVersionFromCommits(currentVersion, commits, {
+        prerelease: options.prerelease,
+      });
 
   if (!nextVersion) {
     throw new Error(
@@ -36,6 +44,7 @@ export function createReleasePlan(options = {}) {
   const resolvedReleaseTagPrefix = options.releaseTagPrefix ?? releaseTagPrefix;
   const generatedAt = options.now ?? new Date();
   const releaseTag = `${resolvedReleaseTagPrefix}${nextVersion}`;
+  const isPrerelease = Boolean(semver.prerelease(nextVersion));
 
   return {
     changelogSection: buildChangelogSection(nextVersion, commits, {
@@ -46,14 +55,20 @@ export function createReleasePlan(options = {}) {
     generatedAt: generatedAt.toISOString(),
     latestTag,
     nextVersion,
+    npmDistTag: isPrerelease ? prereleaseNpmDistTag : stableNpmDistTag,
     packageName: packageJson.name,
     paths,
+    prerelease: isPrerelease,
     releaseTag,
   };
 }
 
-export function resolveReleaseSpecifier(currentVersion, specifier) {
-  return resolveVersionSpecifier(currentVersion, specifier);
+export function resolveReleaseSpecifier(
+  currentVersion,
+  specifier,
+  options = {},
+) {
+  return resolveVersionSpecifier(currentVersion, specifier, options);
 }
 
 export function summarizeReleasePlan(plan) {
@@ -63,7 +78,9 @@ export function summarizeReleasePlan(plan) {
     generatedAt: plan.generatedAt,
     latestTag: plan.latestTag,
     nextVersion: plan.nextVersion,
+    npmDistTag: plan.npmDistTag,
     packageName: plan.packageName,
+    prerelease: plan.prerelease,
     releaseTag: plan.releaseTag,
   };
 }
@@ -75,6 +92,7 @@ export function printReleasePlan(plan) {
   console.log(`Current version: ${summary.currentVersion}`);
   console.log(`Latest tag: ${summary.latestTag ?? 'none'}`);
   console.log(`Next version: ${summary.nextVersion}`);
+  console.log(`npm dist-tag: ${summary.npmDistTag}`);
   console.log(`Release tag: ${summary.releaseTag}`);
   console.log(`Release commits: ${summary.commitCount}`);
 }
@@ -86,23 +104,49 @@ function resolveReleasePaths(paths = {}) {
   };
 }
 
-function resolveVersionSpecifier(currentVersion, specifier) {
+function resolveVersionSpecifier(currentVersion, specifier, options = {}) {
   const trimmedSpecifier = specifier.trim();
 
   if (semver.valid(trimmedSpecifier)) {
+    if (options.prerelease && !semver.prerelease(trimmedSpecifier)) {
+      return appendPrereleaseIdentifier(trimmedSpecifier);
+    }
+
     return trimmedSpecifier;
+  }
+
+  if (options.prerelease) {
+    const prereleaseIncrement = toPrereleaseIncrement(trimmedSpecifier);
+
+    if (prereleaseIncrement) {
+      return semver.inc(
+        currentVersion,
+        prereleaseIncrement,
+        prereleaseIdentifier,
+      );
+    }
   }
 
   return semver.inc(currentVersion, trimmedSpecifier);
 }
 
-function inferVersionFromCommits(currentVersion, commits) {
+function inferVersionFromCommits(currentVersion, commits, options = {}) {
+  const releaseType = inferReleaseTypeFromCommits(commits);
+
+  if (options.prerelease) {
+    return inferPrereleaseVersion(currentVersion, releaseType);
+  }
+
+  return releaseType ? semver.inc(currentVersion, releaseType) : null;
+}
+
+function inferReleaseTypeFromCommits(commits) {
   if (commits.some(isBreakingCommit)) {
-    return semver.inc(currentVersion, 'major');
+    return 'major';
   }
 
   if (commits.some((commit) => getCommitType(commit) === 'feat')) {
-    return semver.inc(currentVersion, 'minor');
+    return 'minor';
   }
 
   if (
@@ -110,10 +154,48 @@ function inferVersionFromCommits(currentVersion, commits) {
       ['fix', 'perf', 'refactor'].includes(getCommitType(commit) ?? ''),
     )
   ) {
-    return semver.inc(currentVersion, 'patch');
+    return 'patch';
   }
 
   return null;
+}
+
+function inferPrereleaseVersion(currentVersion, releaseType) {
+  if (!releaseType) {
+    return null;
+  }
+
+  if (semver.prerelease(currentVersion)) {
+    return semver.inc(currentVersion, 'prerelease', prereleaseIdentifier);
+  }
+
+  return semver.inc(currentVersion, `pre${releaseType}`, prereleaseIdentifier);
+}
+
+function appendPrereleaseIdentifier(version) {
+  const prereleaseVersion = `${version}-${prereleaseIdentifier}.0`;
+
+  if (!semver.valid(prereleaseVersion)) {
+    throw new Error(`Could not create prerelease version from ${version}.`);
+  }
+
+  return prereleaseVersion;
+}
+
+function toPrereleaseIncrement(specifier) {
+  switch (specifier) {
+    case 'major':
+    case 'minor':
+    case 'patch':
+      return `pre${specifier}`;
+    case 'premajor':
+    case 'preminor':
+    case 'prepatch':
+    case 'prerelease':
+      return specifier;
+    default:
+      return null;
+  }
 }
 
 function getLatestTag(currentVersion, { capture, releaseTagPrefix }) {

--- a/tools/release/src/plan.test.mjs
+++ b/tools/release/src/plan.test.mjs
@@ -10,6 +10,20 @@ test('release specifier accepts semver increments and explicit versions', () => 
   assert.equal(resolveReleaseSpecifier('1.2.3', 'patch'), '1.2.4');
   assert.equal(resolveReleaseSpecifier('1.2.3', 'minor'), '1.3.0');
   assert.equal(resolveReleaseSpecifier('1.2.3', '2.0.0'), '2.0.0');
+  assert.equal(
+    resolveReleaseSpecifier('1.2.3', 'minor', { prerelease: true }),
+    '1.3.0-next.0',
+  );
+  assert.equal(
+    resolveReleaseSpecifier('1.2.3', '2.0.0', { prerelease: true }),
+    '2.0.0-next.0',
+  );
+  assert.equal(
+    resolveReleaseSpecifier('1.2.3', '2.0.0-next.2', {
+      prerelease: true,
+    }),
+    '2.0.0-next.2',
+  );
 });
 
 test('release plan infers the next version from conventional commits', () => {
@@ -27,6 +41,8 @@ test('release plan infers the next version from conventional commits', () => {
 
     assert.equal(plan.currentVersion, '1.0.0');
     assert.equal(plan.nextVersion, '1.1.0');
+    assert.equal(plan.npmDistTag, 'latest');
+    assert.equal(plan.prerelease, false);
     assert.equal(plan.releaseTag, 'sanity@1.1.0');
     assert.match(plan.changelogSection, /## 1\.1\.0 \(2026-06-08\)/);
     assert.match(plan.changelogSection, /add release validation/);
@@ -35,14 +51,62 @@ test('release plan infers the next version from conventional commits', () => {
   }
 });
 
-function createReleaseFixture() {
+test('prerelease plan infers next prerelease from conventional commits', () => {
+  const workspace = createReleaseFixture();
+
+  try {
+    const plan = createReleasePlan({
+      capture: createCapture({
+        gitLog:
+          'abc1234\x01feat(sanity): add release validation\x01\x01Alfonso\x02',
+      }),
+      now: new Date('2026-06-08T00:00:00.000Z'),
+      paths: workspace.paths,
+      prerelease: true,
+    });
+
+    assert.equal(plan.currentVersion, '1.0.0');
+    assert.equal(plan.nextVersion, '1.1.0-next.0');
+    assert.equal(plan.npmDistTag, 'next');
+    assert.equal(plan.prerelease, true);
+    assert.equal(plan.releaseTag, 'sanity@1.1.0-next.0');
+    assert.match(plan.changelogSection, /## 1\.1\.0-next\.0 \(2026-06-08\)/);
+  } finally {
+    workspace.cleanup();
+  }
+});
+
+test('prerelease plan increments the current prerelease train', () => {
+  const workspace = createReleaseFixture({ version: '1.1.0-next.0' });
+
+  try {
+    const plan = createReleasePlan({
+      capture: createCapture({
+        gitLog:
+          'abc1234\x01fix(sanity): tighten release validation\x01\x01Alfonso\x02',
+      }),
+      now: new Date('2026-06-08T00:00:00.000Z'),
+      paths: workspace.paths,
+      prerelease: true,
+    });
+
+    assert.equal(plan.currentVersion, '1.1.0-next.0');
+    assert.equal(plan.nextVersion, '1.1.0-next.1');
+    assert.equal(plan.npmDistTag, 'next');
+    assert.equal(plan.releaseTag, 'sanity@1.1.0-next.1');
+  } finally {
+    workspace.cleanup();
+  }
+});
+
+function createReleaseFixture({ version = '1.0.0' } = {}) {
   const directory = mkdtempSync(join(tmpdir(), 'limitless-release-plan-'));
   const packageJsonPath = join(directory, 'package.json');
   const changelogPath = join(directory, 'CHANGELOG.md');
 
   writeFileSync(
     packageJsonPath,
-    `${JSON.stringify({ name: '@limitless-angular/sanity', version: '1.0.0' }, null, 2)}\n`,
+    `${JSON.stringify({ name: '@limitless-angular/sanity', version }, null, 2)}\n`,
   );
   writeFileSync(changelogPath, '## 1.0.0\n');
 

--- a/tools/release/src/publish.mjs
+++ b/tools/release/src/publish.mjs
@@ -23,15 +23,20 @@ export function commitRelease(plan, options = {}) {
 
 export function publishTarball(tarballPath, options = {}) {
   const commandRun = options.run ?? defaultRun;
-
-  commandRun('npm', [
+  const args = [
     'publish',
     tarballPath,
     '--access',
     'public',
     '--registry',
     'https://registry.npmjs.org',
-  ]);
+  ];
+
+  if (options.npmDistTag && options.npmDistTag !== 'latest') {
+    args.push('--tag', options.npmDistTag);
+  }
+
+  commandRun('npm', args);
 }
 
 export function pushRelease(options = {}) {
@@ -53,19 +58,21 @@ export function createGitHubRelease(plan, options = {}) {
 
   try {
     writeFileSync(notesPath, plan.changelogSection);
-    commandRun(
-      'gh',
-      [
-        'release',
-        'create',
-        plan.releaseTag,
-        '--title',
-        plan.releaseTag,
-        '--notes-file',
-        notesPath,
-      ],
-      { env },
-    );
+    const args = [
+      'release',
+      'create',
+      plan.releaseTag,
+      '--title',
+      plan.releaseTag,
+      '--notes-file',
+      notesPath,
+    ];
+
+    if (plan.prerelease) {
+      args.push('--prerelease');
+    }
+
+    commandRun('gh', args, { env });
     return true;
   } finally {
     rmSync(tempDir, { force: true, recursive: true });


### PR DESCRIPTION
## Summary

- add a prerelease checkbox to the release dry-run and publish workflows
- infer `next` prerelease versions from conventional commits and expose the planned npm dist-tag
- publish prerelease artifacts with `npm publish --tag next` and mark GitHub releases as prereleases

## Validation

- `pnpm --filter=@limitless-angular/release-tools test`
- `pnpm exec prettier --check tools/release/cli.mjs tools/release/src/plan.mjs tools/release/src/pipeline.mjs tools/release/src/publish.mjs tools/release/src/plan.test.mjs tools/release/src/pipeline.test.mjs tools/release/README.md .github/workflows/release-and-publish.yml .github/workflows/release-dry-run.yml`
- `pnpm --filter=@limitless-angular/release-tools run --silent release:plan --prerelease --json`
- `pnpm --filter=@limitless-angular/release-tools run --silent release:plan --version 19.3.0 --prerelease --json`
