### PR TITLE
ci: use npm trusted publishing

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -52,7 +52,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: 'pnpm'
-          registry-url: https://registry.npmjs.org/
+
+      - name: Install npm for trusted publishing
+        run: npm install -g npm@^11.10.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
@@ -78,7 +80,6 @@ jobs:
         id: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
           RELEASE_VERBOSE: ${{ inputs.verbose }}
           RELEASE_VERSION: ${{ inputs.version }}

--- a/tools/angular-compat/orchestration-contract.test.mjs
+++ b/tools/angular-compat/orchestration-contract.test.mjs
@@ -190,7 +190,8 @@ test('release workflows delegate to the release tools package', () => {
   assertIncludes(publishWorkflow, [
     turboReleaseCommand('release:publish', { forwardsArgs: true }),
     'environment: npm-release',
-    'NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}',
+    'id-token: write',
+    'npm install -g npm@^11.10.0',
     'NPM_CONFIG_PROVENANCE: true',
   ]);
   assertIncludes(dryRunWorkflow, [
@@ -201,6 +202,9 @@ test('release workflows delegate to the release tools package', () => {
 
   assert.doesNotMatch(publishWorkflow, /compat:pack/);
   assert.doesNotMatch(publishWorkflow, /npm publish/);
+  assert.doesNotMatch(publishWorkflow, /registry-url/);
+  assert.doesNotMatch(publishWorkflow, /NODE_AUTH_TOKEN/);
+  assert.doesNotMatch(publishWorkflow, /NPM_ACCESS_TOKEN/);
   assert.doesNotMatch(dryRunWorkflow, /NODE_AUTH_TOKEN/);
   assert.doesNotMatch(dryRunWorkflow, /NPM_ACCESS_TOKEN/);
 });

--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -65,4 +65,9 @@ does not perform git, npm, or GitHub release side effects.
 Publish mode performs external side effects only after tests, linting, artifact
 validation, and compatibility consumer checks pass. The GitHub workflow also
 targets the `npm-release` environment so repository environment protection rules
-can require approval before npm credentials are exposed.
+can require approval before publishing.
+
+The npm package must trust the GitHub Actions publisher for
+`limitless-angular/limitless-angular`, workflow `release-and-publish.yml`, and
+environment `npm-release`; the publish job uses npm trusted publishing instead
+of a long-lived npm token.


### PR DESCRIPTION
## PR Checklist

Switches the npm publish workflow from long-lived npm token auth to npm trusted publishing for `@limitless-angular/sanity`.

Closes #

## What is the new behavior?

The release workflow now installs npm 11 before publishing, keeps GitHub OIDC enabled, and no longer passes `NPM_ACCESS_TOKEN`/`NODE_AUTH_TOKEN` or setup-node registry token configuration to the publish job. The release workflow contract test now asserts the trusted-publishing setup and guards against reintroducing token publishing. The release docs also document the required npm trusted publisher configuration.

Maintainers still need to configure npm to trust GitHub Actions for `limitless-angular/limitless-angular`, workflow `release-and-publish.yml`, environment `npm-release`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validation run locally:

- `pnpm --filter=@limitless-angular/angular-compat test`
- `pnpm --filter=@limitless-angular/release-tools test`
- `pnpm exec prettier --check .github/workflows/release-and-publish.yml tools/angular-compat/orchestration-contract.test.mjs tools/release/README.md`
- `git diff --check`

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
