### PR TITLE
ci: fix release workflow temp path

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -30,8 +30,6 @@ jobs:
     if: github.repository == 'limitless-angular/limitless-angular'
     name: Release and Publish to npm
     runs-on: ubuntu-22.04
-    env:
-      RELEASE_PLAN_PATH: ${{ runner.temp }}/release-plan.json
     permissions:
       contents: write
       id-token: write
@@ -64,6 +62,9 @@ jobs:
           echo "Node version: $(node -v)"
           echo "pnpm version: $(pnpm -v)"
           echo "Workspace directory: $(pwd)"
+
+      - name: Configure release paths
+        run: echo "RELEASE_PLAN_PATH=$RUNNER_TEMP/release-plan.json" >> "$GITHUB_ENV"
 
       - name: Run tests
         run: pnpm turbo run test

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -30,8 +30,6 @@ jobs:
     if: github.repository == 'limitless-angular/limitless-angular'
     name: Validate Release Dry Run
     runs-on: ubuntu-22.04
-    env:
-      RELEASE_PLAN_PATH: ${{ runner.temp }}/release-plan.json
     permissions:
       contents: read
     steps:
@@ -60,6 +58,9 @@ jobs:
           echo "Node version: $(node -v)"
           echo "pnpm version: $(pnpm -v)"
           echo "Workspace directory: $(pwd)"
+
+      - name: Configure release paths
+        run: echo "RELEASE_PLAN_PATH=$RUNNER_TEMP/release-plan.json" >> "$GITHUB_ENV"
 
       - name: Run tests
         run: pnpm turbo run test

--- a/tools/angular-compat/orchestration-contract.test.mjs
+++ b/tools/angular-compat/orchestration-contract.test.mjs
@@ -191,6 +191,7 @@ test('release workflows delegate to the release tools package', () => {
     turboReleaseCommand('release:publish', { forwardsArgs: true }),
     'environment: npm-release',
     'id-token: write',
+    'echo "RELEASE_PLAN_PATH=$RUNNER_TEMP/release-plan.json" >> "$GITHUB_ENV"',
     'npm install -g npm@^11.10.0',
     'NPM_CONFIG_PROVENANCE: true',
   ]);
@@ -198,13 +199,16 @@ test('release workflows delegate to the release tools package', () => {
     turboReleaseCommand('release:dry-run', { forwardsArgs: true }),
     'permissions:',
     'contents: read',
+    'echo "RELEASE_PLAN_PATH=$RUNNER_TEMP/release-plan.json" >> "$GITHUB_ENV"',
   ]);
 
+  assert.doesNotMatch(publishWorkflow, /runner\.temp/);
   assert.doesNotMatch(publishWorkflow, /compat:pack/);
   assert.doesNotMatch(publishWorkflow, /npm publish/);
   assert.doesNotMatch(publishWorkflow, /registry-url/);
   assert.doesNotMatch(publishWorkflow, /NODE_AUTH_TOKEN/);
   assert.doesNotMatch(publishWorkflow, /NPM_ACCESS_TOKEN/);
+  assert.doesNotMatch(dryRunWorkflow, /runner\.temp/);
   assert.doesNotMatch(dryRunWorkflow, /NODE_AUTH_TOKEN/);
   assert.doesNotMatch(dryRunWorkflow, /NPM_ACCESS_TOKEN/);
 });


### PR DESCRIPTION
## PR Checklist

Fixes the release workflows so GitHub can parse and dispatch them. The previous job-level `runner.temp` expression is not available during workflow parsing, which caused `gh workflow run release-dry-run.yml --ref main` to fail with HTTP 422.

Closes #

## What is the new behavior?

Both release workflows now write `RELEASE_PLAN_PATH=$RUNNER_TEMP/release-plan.json` through `$GITHUB_ENV` from a runner step. The release workflow contract test now asserts the `$GITHUB_ENV` setup and rejects future `runner.temp` usage in these workflows.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validation run locally:

- `pnpm --filter=@limitless-angular/angular-compat test`
- `pnpm exec prettier --check .github/workflows/release-dry-run.yml .github/workflows/release-and-publish.yml tools/angular-compat/orchestration-contract.test.mjs`
- `git diff --check`

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
