### PR TITLE
ci(release): add publish guardrails

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   release-and-publish:
-    if: github.repository == 'limitless-angular/limitless-angular'
+    if: github.repository == 'limitless-angular/limitless-angular' && github.ref == 'refs/heads/main'
     name: Release and Publish to npm
     runs-on: ubuntu-22.04
     permissions:

--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -39,13 +39,18 @@ Both dry-run and publish mode use the same release pipeline:
 
 1. Compute the release plan from the current package version, explicit version
    input, or conventional commits.
-2. Apply the planned package version and changelog to the runner workspace.
-3. Build one compatibility artifact with `compat:pack`.
-4. Validate artifact shape with `compat:artifact`.
-5. Assert the packed artifact version equals the planned next version.
-6. Install the Playwright browser used by compatibility consumers.
-7. Test the same artifact with `compat:test`.
-8. In publish mode only, commit, tag, publish the tarball to npm, push the
+2. In publish mode only, verify the release is running from `main`, the
+   worktree matches `origin/main`, the release tag is unused, the planned npm
+   version is unpublished, and `GITHUB_TOKEN` is available for the GitHub
+   release.
+3. Apply the planned package version and changelog to the runner workspace.
+4. Build one compatibility artifact with `compat:pack`.
+5. Validate artifact shape with `compat:artifact`.
+6. Assert the packed artifact version equals the planned next version.
+7. Install the Playwright browser used by compatibility consumers.
+8. Test the same artifact with `compat:test`.
+9. In publish mode only, commit, tag, re-check the remote release branch, npm
+   version, and remote tag, publish the tarball to npm, push the
    release commit and tag, and create the GitHub release.
 
 Prerelease versions are published to npm with the `next` dist-tag and their
@@ -63,9 +68,10 @@ planned `nextVersion`. It never receives npm credentials in GitHub Actions and
 does not perform git, npm, or GitHub release side effects.
 
 Publish mode performs external side effects only after tests, linting, artifact
-validation, and compatibility consumer checks pass. The GitHub workflow also
-targets the `npm-release` environment so repository environment protection rules
-can require approval before publishing.
+validation, compatibility consumer checks, and publish preflights pass. The
+GitHub workflow only runs publish from `main` and targets the `npm-release`
+environment so repository environment protection rules can require approval
+before publishing.
 
 The npm package must trust the GitHub Actions publisher for
 `limitless-angular/limitless-angular`, workflow `release-and-publish.yml`, and

--- a/tools/release/src/pipeline.mjs
+++ b/tools/release/src/pipeline.mjs
@@ -7,6 +7,10 @@ import {
   publishTarball,
   pushRelease,
 } from './publish.mjs';
+import {
+  assertFinalPublishPreconditions,
+  assertPublishPreconditions,
+} from './preflight.mjs';
 import { applyReleasePlan, restoreReleaseFiles } from './workspace.mjs';
 
 export const releaseModes = {
@@ -78,6 +82,14 @@ export function runReleasePipeline(options = {}) {
     printReleasePlan(plan);
   }
 
+  if (mode === releaseModes.publish) {
+    assertPublishPreconditions(plan, {
+      capture: commandCapture,
+      env: options.env,
+      run: commandRun,
+    });
+  }
+
   try {
     snapshot = applyReleasePlan(plan);
 
@@ -89,6 +101,11 @@ export function runReleasePipeline(options = {}) {
     if (mode === releaseModes.publish) {
       publishSideEffectsStarted = true;
       commitRelease(plan, { run: commandRun });
+      assertFinalPublishPreconditions(plan, {
+        capture: commandCapture,
+        env: options.env,
+        run: commandRun,
+      });
       publishTarball(artifact.tarballPath, {
         npmDistTag: plan.npmDistTag,
         run: commandRun,

--- a/tools/release/src/pipeline.test.mjs
+++ b/tools/release/src/pipeline.test.mjs
@@ -67,6 +67,7 @@ test('publish mode validates before starting release side effects', () => {
         tarballPath: '/tmp/release.tgz',
       },
       capture: createCapture(),
+      env: { GITHUB_REF: 'refs/heads/main', GITHUB_TOKEN: 'token' },
       mode: releaseModes.publish,
       now: new Date('2026-06-08T00:00:00.000Z'),
       paths: fixture.paths,
@@ -81,16 +82,25 @@ test('publish mode validates before starting release side effects', () => {
       [command, ...args].join(' '),
     );
     const compatibilityCommandCount = compatibilityValidationSteps.length;
+    const compatibilityStart = commandIds.findIndex(
+      (command) =>
+        command ===
+        'pnpm turbo run compat:pack --filter=@limitless-angular/angular-compat',
+    );
+    assert.notEqual(compatibilityStart, -1);
 
     assert.deepEqual(
       commands
-        .slice(0, compatibilityCommandCount)
+        .slice(
+          compatibilityStart,
+          compatibilityStart + compatibilityCommandCount,
+        )
         .map(({ command, args }) => [command, args]),
       compatibilityValidationSteps.map(({ command, args }) => [command, args]),
     );
     assert.ok(
       commandIds.findIndex((command) => command.startsWith('git add ')) >
-        compatibilityCommandCount - 1,
+        compatibilityStart + compatibilityCommandCount - 1,
     );
     assert.ok(
       commandIds.findIndex((command) => command.startsWith('npm publish ')) >
@@ -125,7 +135,7 @@ test('publish mode tags npm and GitHub prereleases', () => {
         gitLog:
           'abc1234\x01feat(sanity): add release validation\x01\x01Alfonso\x02',
       }),
-      env: { GITHUB_TOKEN: 'token' },
+      env: { GITHUB_REF: 'refs/heads/main', GITHUB_TOKEN: 'token' },
       mode: releaseModes.publish,
       now: new Date('2026-06-08T00:00:00.000Z'),
       paths: fixture.paths,
@@ -176,6 +186,7 @@ test('artifact version mismatch fails before publish side effects', () => {
             tarballPath: '/tmp/release.tgz',
           },
           capture: createCapture(),
+          env: { GITHUB_REF: 'refs/heads/main', GITHUB_TOKEN: 'token' },
           mode: releaseModes.publish,
           now: new Date('2026-06-08T00:00:00.000Z'),
           paths: fixture.paths,
@@ -187,7 +198,11 @@ test('artifact version mismatch fails before publish side effects', () => {
 
     assert.equal(readPackageVersion(fixture.paths.packageJsonPath), '1.0.0');
     assert.equal(
-      commands.some(({ command }) => command === 'git' || command === 'npm'),
+      commands.some(
+        ({ command, args }) =>
+          (command === 'git' && args[0] === 'add') ||
+          (command === 'npm' && args[0] === 'publish'),
+      ),
       false,
     );
   } finally {
@@ -214,14 +229,47 @@ function createReleaseFixture() {
   };
 }
 
-function createCapture({ gitLog = '' } = {}) {
+function createCapture({ gitLog = '', npmVersions = ['1.0.0'] } = {}) {
   return (command, args) => {
-    if (command === 'git' && args[0] === 'rev-parse') {
+    if (command === 'git' && args[0] === 'status') {
       return '';
+    }
+
+    if (command === 'git' && args[0] === 'branch') {
+      return 'main';
+    }
+
+    if (
+      command === 'git' &&
+      args[0] === 'rev-parse' &&
+      args[1] === '--verify' &&
+      args[2]?.startsWith('refs/tags/')
+    ) {
+      throw new Error(`Missing tag ${args[2]}`);
+    }
+
+    if (command === 'git' && args[0] === 'rev-parse') {
+      if (args[1] === 'HEAD' || args[1] === 'origin/main') {
+        return 'main-sha';
+      }
+
+      return '';
+    }
+
+    if (command === 'git' && args[0] === 'merge-base') {
+      return 'main-sha';
     }
 
     if (command === 'git' && args[0] === 'log') {
       return gitLog;
+    }
+
+    if (command === 'git' && args[0] === 'ls-remote') {
+      throw new Error(`Missing remote tag ${args.at(-1)}`);
+    }
+
+    if (command === 'npm' && args[0] === 'view') {
+      return JSON.stringify(npmVersions);
     }
 
     throw new Error(`Unexpected command: ${command} ${args.join(' ')}`);

--- a/tools/release/src/plan.mjs
+++ b/tools/release/src/plan.mjs
@@ -37,8 +37,10 @@ export function createReleasePlan(options = {}) {
     );
   }
 
-  if (nextVersion === currentVersion) {
-    throw new Error(`Refusing to release unchanged version ${currentVersion}.`);
+  if (!semver.gt(nextVersion, currentVersion)) {
+    throw new Error(
+      `Refusing to release ${nextVersion}; it must be greater than the current version ${currentVersion}.`,
+    );
   }
 
   const resolvedReleaseTagPrefix = options.releaseTagPrefix ?? releaseTagPrefix;

--- a/tools/release/src/plan.test.mjs
+++ b/tools/release/src/plan.test.mjs
@@ -26,6 +26,35 @@ test('release specifier accepts semver increments and explicit versions', () => 
   );
 });
 
+test('release plan rejects explicit versions that do not move forward', () => {
+  const workspace = createReleaseFixture({ version: '1.2.3' });
+
+  try {
+    assert.throws(
+      () =>
+        createReleasePlan({
+          capture: createCapture({ gitLog: '' }),
+          now: new Date('2026-06-08T00:00:00.000Z'),
+          paths: workspace.paths,
+          versionSpecifier: '1.2.2',
+        }),
+      /must be greater than the current version 1\.2\.3/,
+    );
+    assert.throws(
+      () =>
+        createReleasePlan({
+          capture: createCapture({ gitLog: '' }),
+          now: new Date('2026-06-08T00:00:00.000Z'),
+          paths: workspace.paths,
+          versionSpecifier: '1.2.3',
+        }),
+      /must be greater than the current version 1\.2\.3/,
+    );
+  } finally {
+    workspace.cleanup();
+  }
+});
+
 test('release plan infers the next version from conventional commits', () => {
   const workspace = createReleaseFixture();
 

--- a/tools/release/src/preflight.mjs
+++ b/tools/release/src/preflight.mjs
@@ -1,0 +1,178 @@
+import { capture as defaultCapture, run as defaultRun } from './commands.mjs';
+
+const defaultReleaseBranch = 'main';
+const npmRegistry = 'https://registry.npmjs.org';
+
+export function assertPublishPreconditions(plan, options = {}) {
+  const commandCapture = options.capture ?? defaultCapture;
+  const commandRun = options.run ?? defaultRun;
+  const env = { ...process.env, ...options.env };
+  const releaseBranch = getReleaseBranch(env, options);
+
+  assertGitHubReleaseToken(env);
+  assertReleaseRef({ capture: commandCapture, env, releaseBranch });
+  assertCleanWorktree(commandCapture);
+  syncReleaseBranch(commandRun, releaseBranch);
+  assertHeadMatchesRemote(commandCapture, releaseBranch);
+  assertLocalReleaseTagAvailable(plan, commandCapture);
+  assertRemoteReleaseTagAvailable(plan, commandCapture);
+  assertNpmVersionAvailable(plan, commandCapture);
+}
+
+export function assertFinalPublishPreconditions(plan, options = {}) {
+  const commandCapture = options.capture ?? defaultCapture;
+  const commandRun = options.run ?? defaultRun;
+  const env = { ...process.env, ...options.env };
+  const releaseBranch = getReleaseBranch(env, options);
+
+  syncReleaseBranch(commandRun, releaseBranch);
+  assertRemoteBranchStillInHistory(commandCapture, releaseBranch);
+  assertRemoteReleaseTagAvailable(plan, commandCapture);
+  assertNpmVersionAvailable(plan, commandCapture);
+}
+
+function getReleaseBranch(env, options) {
+  return options.releaseBranch ?? env.RELEASE_BRANCH ?? defaultReleaseBranch;
+}
+
+function assertGitHubReleaseToken(env) {
+  if (!env.GITHUB_TOKEN) {
+    throw new Error(
+      'Refusing to publish without GITHUB_TOKEN; publish mode must be able to create the GitHub release.',
+    );
+  }
+}
+
+function assertReleaseRef({ capture, env, releaseBranch }) {
+  const expectedGitHubRef = `refs/heads/${releaseBranch}`;
+
+  if (env.GITHUB_REF) {
+    if (env.GITHUB_REF !== expectedGitHubRef) {
+      throw new Error(
+        `Refusing to publish from ${env.GITHUB_REF}; expected ${expectedGitHubRef}.`,
+      );
+    }
+
+    return;
+  }
+
+  const currentBranch = capture('git', ['branch', '--show-current']).trim();
+  if (currentBranch !== releaseBranch) {
+    throw new Error(
+      `Refusing to publish from branch ${currentBranch || 'detached HEAD'}; expected ${releaseBranch}.`,
+    );
+  }
+}
+
+function assertCleanWorktree(capture) {
+  const status = capture('git', ['status', '--porcelain']).trim();
+  if (status) {
+    throw new Error('Refusing to publish with uncommitted workspace changes.');
+  }
+}
+
+function syncReleaseBranch(run, releaseBranch) {
+  run('git', [
+    'fetch',
+    'origin',
+    `refs/heads/${releaseBranch}:refs/remotes/origin/${releaseBranch}`,
+    '--tags',
+  ]);
+}
+
+function assertHeadMatchesRemote(capture, releaseBranch) {
+  const head = capture('git', ['rev-parse', 'HEAD']).trim();
+  const remoteHead = capture('git', [
+    'rev-parse',
+    `origin/${releaseBranch}`,
+  ]).trim();
+
+  if (head !== remoteHead) {
+    throw new Error(
+      `Refusing to publish because HEAD (${head}) does not match origin/${releaseBranch} (${remoteHead}).`,
+    );
+  }
+}
+
+function assertRemoteBranchStillInHistory(capture, releaseBranch) {
+  const remoteHead = capture('git', [
+    'rev-parse',
+    `origin/${releaseBranch}`,
+  ]).trim();
+  const mergeBase = capture('git', [
+    'merge-base',
+    'HEAD',
+    `origin/${releaseBranch}`,
+  ]).trim();
+
+  if (mergeBase !== remoteHead) {
+    throw new Error(
+      `Refusing to publish because origin/${releaseBranch} moved after validation.`,
+    );
+  }
+}
+
+function assertLocalReleaseTagAvailable(plan, capture) {
+  if (
+    commandSucceeds(capture, 'git', [
+      'rev-parse',
+      '--verify',
+      `refs/tags/${plan.releaseTag}`,
+    ])
+  ) {
+    throw new Error(
+      `Refusing to publish because local tag ${plan.releaseTag} already exists.`,
+    );
+  }
+}
+
+function assertRemoteReleaseTagAvailable(plan, capture) {
+  if (
+    commandSucceeds(capture, 'git', [
+      'ls-remote',
+      '--exit-code',
+      '--tags',
+      'origin',
+      `refs/tags/${plan.releaseTag}`,
+    ])
+  ) {
+    throw new Error(
+      `Refusing to publish because remote tag ${plan.releaseTag} already exists.`,
+    );
+  }
+}
+
+function assertNpmVersionAvailable(plan, capture) {
+  const output = capture('npm', [
+    'view',
+    plan.packageName,
+    'versions',
+    '--json',
+    '--registry',
+    npmRegistry,
+  ]);
+  const versions = normalizeNpmVersions(JSON.parse(output));
+
+  if (versions.includes(plan.nextVersion)) {
+    throw new Error(
+      `Refusing to publish because ${plan.packageName}@${plan.nextVersion} already exists on npm.`,
+    );
+  }
+}
+
+function normalizeNpmVersions(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  return value ? [value] : [];
+}
+
+function commandSucceeds(capture, command, args) {
+  try {
+    capture(command, args);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tools/release/src/preflight.test.mjs
+++ b/tools/release/src/preflight.test.mjs
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  assertFinalPublishPreconditions,
+  assertPublishPreconditions,
+} from './preflight.mjs';
+
+const plan = {
+  nextVersion: '1.1.0',
+  packageName: '@limitless-angular/sanity',
+  releaseTag: 'sanity@1.1.0',
+};
+
+test('publish preflight rejects non-main GitHub refs', () => {
+  assert.throws(
+    () =>
+      assertPublishPreconditions(plan, {
+        capture: createCapture(),
+        env: { GITHUB_REF: 'refs/heads/release-test', GITHUB_TOKEN: 'token' },
+        run: recordRun(),
+      }),
+    /expected refs\/heads\/main/,
+  );
+});
+
+test('publish preflight rejects missing GitHub release tokens', () => {
+  assert.throws(
+    () =>
+      assertPublishPreconditions(plan, {
+        capture: createCapture(),
+        env: { GITHUB_REF: 'refs/heads/main', GITHUB_TOKEN: '' },
+        run: recordRun(),
+      }),
+    /without GITHUB_TOKEN/,
+  );
+});
+
+test('publish preflight rejects dirty worktrees', () => {
+  assert.throws(
+    () =>
+      assertPublishPreconditions(plan, {
+        capture: createCapture({ status: ' M packages/sanity/package.json\n' }),
+        env: { GITHUB_REF: 'refs/heads/main', GITHUB_TOKEN: 'token' },
+        run: recordRun(),
+      }),
+    /uncommitted workspace changes/,
+  );
+});
+
+test('publish preflight rejects already-published npm versions', () => {
+  assert.throws(
+    () =>
+      assertPublishPreconditions(plan, {
+        capture: createCapture({ npmVersions: ['1.0.0', '1.1.0'] }),
+        env: { GITHUB_REF: 'refs/heads/main', GITHUB_TOKEN: 'token' },
+        run: recordRun(),
+      }),
+    /already exists on npm/,
+  );
+});
+
+test('final publish preflight rejects a moved release branch', () => {
+  assert.throws(
+    () =>
+      assertFinalPublishPreconditions(plan, {
+        capture: createCapture({
+          mergeBase: 'old-main-sha',
+          remoteHead: 'new-main-sha',
+        }),
+        env: { GITHUB_REF: 'refs/heads/main', GITHUB_TOKEN: 'token' },
+        run: recordRun(),
+      }),
+    /origin\/main moved after validation/,
+  );
+});
+
+function createCapture({
+  head = 'main-sha',
+  mergeBase = 'main-sha',
+  npmVersions = ['1.0.0'],
+  remoteHead = 'main-sha',
+  status = '',
+} = {}) {
+  return (command, args) => {
+    if (command === 'git' && args[0] === 'status') {
+      return status;
+    }
+
+    if (command === 'git' && args[0] === 'branch') {
+      return 'main';
+    }
+
+    if (command === 'git' && args[0] === 'rev-parse' && args[1] === 'HEAD') {
+      return head;
+    }
+
+    if (
+      command === 'git' &&
+      args[0] === 'rev-parse' &&
+      args[1] === 'origin/main'
+    ) {
+      return remoteHead;
+    }
+
+    if (
+      command === 'git' &&
+      args[0] === 'rev-parse' &&
+      args[1] === '--verify'
+    ) {
+      throw new Error(`Missing local tag ${args[2]}`);
+    }
+
+    if (command === 'git' && args[0] === 'merge-base') {
+      return mergeBase;
+    }
+
+    if (command === 'git' && args[0] === 'ls-remote') {
+      throw new Error(`Missing remote tag ${args.at(-1)}`);
+    }
+
+    if (command === 'npm' && args[0] === 'view') {
+      return JSON.stringify(npmVersions);
+    }
+
+    throw new Error(`Unexpected command: ${command} ${args.join(' ')}`);
+  };
+}
+
+function recordRun() {
+  return () => {};
+}

--- a/tools/release/src/publish.mjs
+++ b/tools/release/src/publish.mjs
@@ -50,7 +50,7 @@ export function createGitHubRelease(plan, options = {}) {
   const env = { ...process.env, ...options.env };
 
   if (!env.GITHUB_TOKEN) {
-    return false;
+    throw new Error('Missing GITHUB_TOKEN; cannot create the GitHub release.');
   }
 
   const tempDir = mkdtempSync(join(tmpdir(), 'limitless-release-'));


### PR DESCRIPTION
## PR Checklist

Closes #

## What is the new behavior?

This PR tightens the release/publish path before the next manual trigger:

- Restricts the `Release and Publish` workflow to the canonical `main` ref.
- Adds a release preflight module that verifies publish mode has a clean workspace, is on `main`, matches `origin/main`, has an unused release tag, has an unpublished npm version, and has `GITHUB_TOKEN` available for the GitHub release.
- Re-checks `origin/main`, the remote tag, and the npm version after the release commit/tag is created but before `npm publish` runs.
- Rejects explicit release versions that do not move semver forward.
- Fails GitHub release creation when `GITHUB_TOKEN` is missing instead of silently skipping it.

Architecture notes:

- GitHub Actions remains thin and only owns the earliest ref gate.
- Release safety logic lives in `tools/release/src/preflight.mjs`, keeping planning, artifact validation, workspace mutation, and publishing as separate responsibilities.
- The preflight functions accept injected `capture`/`run` adapters, matching the existing release-tool test style and avoiding hard-to-test global command coupling.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validated with:

- `pnpm --filter=@limitless-angular/release-tools test`
- `pnpm turbo run compat:release-parity --filter=@limitless-angular/angular-compat`
- `pnpm turbo run compat:assert --filter=@limitless-angular/angular-compat`
- `git diff --check`

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
