### PR TITLE
feat: add Angular version support skill

### DIFF
--- a/.agents/skills/angular-version-support/SKILL.md
+++ b/.agents/skills/angular-version-support/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: angular-version-support
+description: Deterministic support for adding, validating, or updating Angular major-version compatibility in the limitless-angular workspace. Use when Codex is asked to add support for a new Angular version, update the Angular peer matrix, validate Angular compatibility, or adjust this repo's Angular compatibility harness, especially for @limitless-angular/sanity.
+---
+
+# Angular Version Support
+
+Use this skill for repo-specific Angular compatibility work in the
+`limitless-angular` workspace.
+
+Before changing files, read
+[`references/limitless-angular-compat.md`](references/limitless-angular-compat.md).
+
+## Workflow
+
+1. Identify the requested Angular major from the user prompt.
+   - If no target major is present, ask for the Angular major before mutating files.
+   - Treat prompts like "Angular 20", "v20", and "major 20" as target major `20`.
+2. Use the deterministic helper when the task is to add a stable Angular major:
+
+   ```bash
+   node .agents/skills/angular-version-support/scripts/add-angular-version.ts --major <major>
+   ```
+
+   Use `--dry-run` before applying when the user asks for a preview.
+3. Audit the project-specific compatibility files listed in the reference.
+4. Run the focused validation commands from the reference.
+5. If general Angular coding changes are required, use `$angular-developer` after
+   the compatibility matrix has been updated.
+
+## Rules
+
+- Do not use Python for this skill's workflow or bundled scripts.
+- Keep bundled scripts executable with plain Node 22; do not require `tsx`,
+  `ts-node`, build steps, or a custom runner.
+- Do not mass-upgrade demo app Angular dependency pins unless the user
+  explicitly asks for a workspace upgrade.
+- Keep stable compatibility rows deterministic: one `floor` row and one
+  `latest` row for every supported Angular major.

--- a/.agents/skills/angular-version-support/agents/openai.yaml
+++ b/.agents/skills/angular-version-support/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Angular Version Support"
+  short_description: "Update this repo's Angular support matrix"
+  default_prompt: "Use $angular-version-support to add support for Angular 20."

--- a/.agents/skills/angular-version-support/references/limitless-angular-compat.md
+++ b/.agents/skills/angular-version-support/references/limitless-angular-compat.md
@@ -1,0 +1,89 @@
+# Limitless Angular Compatibility Contract
+
+This workspace publishes `@limitless-angular/sanity` and verifies Angular
+support through the private `@limitless-angular/angular-compat` package.
+Adding support for a stable Angular major means updating the public peer range
+and the generated-consumer compatibility matrix.
+
+## Required Files
+
+- `packages/sanity/package.json`
+  - Update `peerDependencies.@angular/common`.
+  - Update `peerDependencies.@angular/core`.
+  - Update `peerDependencies.@angular/router`.
+  - Keep these three Angular peer ranges identical.
+- `tools/angular-compat/config.json`
+  - Add `angular-<major>-floor` with `mode: "floor"`.
+  - Add `angular-<major>-latest` with `mode: "latest"`.
+  - Set `buildAngularMajor` to the newest stable major represented by
+    `consumerVersionSets`.
+
+Use the helper for this deterministic edit:
+
+```bash
+node .agents/skills/angular-version-support/scripts/add-angular-version.ts --major <major>
+```
+
+The helper also backfills missing `floor`/`latest` rows for stable Angular
+majors that are already declared by the peer range or compatibility config.
+
+For a preview:
+
+```bash
+node .agents/skills/angular-version-support/scripts/add-angular-version.ts --major <major> --dry-run
+```
+
+## Required Audit
+
+After the deterministic edit, search for version-specific branches and stale
+contract text:
+
+```bash
+rg 'VERSION|isAngularVersionLessThan|angular-[0-9]|Angular [0-9]' \
+  packages/sanity tools/angular-compat .github tools/release package.json
+```
+
+Always inspect `packages/sanity/shared/src/angular-versions.ts`. Update it only
+when the requested Angular support changes a real runtime branch or minimum
+version check.
+
+Treat these as compatibility contract surfaces:
+
+- `tools/angular-compat/*.test.mjs`
+- `tools/angular-compat/orchestration-contract.test.mjs`
+- `.github/workflows/ci.yml`
+- `.github/workflows/release-and-publish.yml`
+- `.github/workflows/release-dry-run.yml`
+- `tools/release/src/pipeline.mjs`
+
+Do not change these files only because a new major was added. Change them when
+tests reveal a contract drift or when the user asks to update the orchestration.
+
+## Demo App Pins
+
+The demo and e2e Angular apps currently pin their own Angular toolchains. Do
+not upgrade those app dependencies as part of "add Angular support" unless the
+user asks for a workspace or example-app upgrade. The compatibility harness
+builds and tests generated consumers separately from the demo apps.
+
+## Validation
+
+Run focused validation after updating the support matrix:
+
+```bash
+node --test tools/angular-compat/*.test.mjs
+pnpm run compat:assert
+pnpm run compat:matrix
+```
+
+For real support changes, also run:
+
+```bash
+pnpm run compat:pack
+pnpm run compat:artifact
+pnpm run compat:test --angular <major>
+```
+
+The root `compat:test` script already forwards arguments to the compat package.
+If `compat:test --angular <major>` reports no latest row, re-check
+`tools/angular-compat/config.json` for `angular-<major>-latest`.

--- a/.agents/skills/angular-version-support/scripts/add-angular-version.ts
+++ b/.agents/skills/angular-version-support/scripts/add-angular-version.ts
@@ -1,0 +1,334 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const workspacePackageName = '@limitless-angular/source';
+const sanityPackageRelativePath = 'packages/sanity/package.json';
+const compatConfigRelativePath = 'tools/angular-compat/config.json';
+const angularPeerDependencies = [
+  '@angular/common',
+  '@angular/core',
+  '@angular/router',
+];
+const versionSetModeOrder = new Map([
+  ['floor', 0],
+  ['latest', 1],
+]);
+
+main();
+
+function main() {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+      printUsage();
+      return;
+    }
+
+    const major = parseMajor(args.major);
+    const workspaceRoot = args.workspace
+      ? resolve(args.workspace)
+      : findWorkspaceRoot(process.cwd());
+    assertWorkspaceRoot(workspaceRoot);
+    const supportedMajors = readSupportedAngularMajors(workspaceRoot);
+    supportedMajors.add(major);
+
+    const changes = [];
+    updateJsonFile(
+      workspaceRoot,
+      sanityPackageRelativePath,
+      (packageJson) => updateSanityPeerDependencies(packageJson, supportedMajors),
+      { changes, dryRun: args.dryRun },
+    );
+    updateJsonFile(
+      workspaceRoot,
+      compatConfigRelativePath,
+      (config) => updateCompatibilityConfig(config, supportedMajors),
+      { changes, dryRun: args.dryRun },
+    );
+
+    printResult({ changes, dryRun: args.dryRun, major });
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}
+
+function parseArgs(argv) {
+  const args = {
+    dryRun: false,
+    help: false,
+    major: undefined,
+    workspace: undefined,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+
+    if (value === '--dry-run') {
+      args.dryRun = true;
+      continue;
+    }
+
+    if (value === '--help' || value === '-h') {
+      args.help = true;
+      continue;
+    }
+
+    if (value === '--major') {
+      args.major = readOptionValue(argv, index, '--major');
+      index += 1;
+      continue;
+    }
+
+    if (value === '--workspace') {
+      args.workspace = readOptionValue(argv, index, '--workspace');
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${value}`);
+  }
+
+  return args;
+}
+
+function readOptionValue(argv, index, option) {
+  const value = argv[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`Missing value for ${option}`);
+  }
+
+  return value;
+}
+
+function parseMajor(value) {
+  if (!value || !/^\d+$/.test(value)) {
+    throw new Error('Missing or invalid --major value; expected an integer Angular major.');
+  }
+
+  const major = Number(value);
+  if (!Number.isSafeInteger(major) || major < 1) {
+    throw new Error(`Invalid Angular major: ${value}`);
+  }
+
+  return major;
+}
+
+function findWorkspaceRoot(startPath) {
+  let current = resolve(startPath);
+
+  while (true) {
+    const packageJsonPath = join(current, 'package.json');
+    if (existsSync(packageJsonPath)) {
+      const packageJson = readJson(packageJsonPath);
+      if (packageJson.name === workspacePackageName) {
+        return current;
+      }
+    }
+
+    const parent = dirname(current);
+    if (parent === current) {
+      throw new Error(
+        `Unable to find workspace root with package name ${workspacePackageName}. Use --workspace.`,
+      );
+    }
+    current = parent;
+  }
+}
+
+function assertWorkspaceRoot(workspaceRoot) {
+  const packageJsonPath = join(workspaceRoot, 'package.json');
+  if (!existsSync(packageJsonPath)) {
+    throw new Error(`Workspace package.json not found: ${packageJsonPath}`);
+  }
+
+  const packageJson = readJson(packageJsonPath);
+  if (packageJson.name !== workspacePackageName) {
+    throw new Error(
+      `Expected workspace package ${workspacePackageName}, found ${packageJson.name ?? 'unknown'}.`,
+    );
+  }
+}
+
+function updateJsonFile(workspaceRoot, relativePath, updater, options) {
+  const path = join(workspaceRoot, relativePath);
+  const beforeText = readFileSync(path, 'utf8');
+  const beforeJson = JSON.parse(beforeText);
+  const afterJson = updater(beforeJson);
+  const afterText = `${JSON.stringify(afterJson, null, 2)}\n`;
+
+  if (afterText === beforeText) {
+    return;
+  }
+
+  options.changes.push(relativePath);
+  if (!options.dryRun) {
+    writeFileSync(path, afterText);
+  }
+}
+
+function updateSanityPeerDependencies(packageJson, supportedMajors) {
+  const peerDependencies = packageJson.peerDependencies;
+  if (!peerDependencies || typeof peerDependencies !== 'object') {
+    throw new Error(`${sanityPackageRelativePath} must define peerDependencies.`);
+  }
+
+  const peerRange = [...supportedMajors]
+    .sort((left, right) => left - right)
+    .map((peerMajor) => `^${peerMajor}.0.0`)
+    .join(' || ');
+
+  for (const dependency of angularPeerDependencies) {
+    peerDependencies[dependency] = peerRange;
+  }
+
+  return packageJson;
+}
+
+function readSupportedAngularMajors(workspaceRoot) {
+  const packageJson = readJson(join(workspaceRoot, sanityPackageRelativePath));
+  const config = readJson(join(workspaceRoot, compatConfigRelativePath));
+  const majors = new Set();
+  const peerDependencies = packageJson.peerDependencies;
+  if (!peerDependencies || typeof peerDependencies !== 'object') {
+    throw new Error(`${sanityPackageRelativePath} must define peerDependencies.`);
+  }
+
+  for (const dependency of angularPeerDependencies) {
+    const range = peerDependencies[dependency];
+    if (!range) {
+      throw new Error(`Missing Angular peer dependency ${dependency}.`);
+    }
+
+    for (const peerMajor of parseAngularPeerRange(range, dependency)) {
+      majors.add(peerMajor);
+    }
+  }
+
+  if (!Array.isArray(config.consumerVersionSets)) {
+    throw new Error(`${compatConfigRelativePath} must define consumerVersionSets.`);
+  }
+
+  for (const versionSet of config.consumerVersionSets) {
+    if (Number.isInteger(versionSet.angularMajor)) {
+      majors.add(versionSet.angularMajor);
+    }
+  }
+
+  return majors;
+}
+
+function parseAngularPeerRange(range, dependency) {
+  const parts = String(range)
+    .split('||')
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (parts.length === 0) {
+    throw new Error(`Empty Angular peer range for ${dependency}.`);
+  }
+
+  return parts.map((part) => {
+    const match = part.match(/^\^(\d+)\.0\.0$/);
+    if (!match) {
+      throw new Error(
+        `Cannot safely rewrite ${dependency} peer range "${range}". Expected ^<major>.0.0 entries joined by ||.`,
+      );
+    }
+
+    return Number(match[1]);
+  });
+}
+
+function updateCompatibilityConfig(config, supportedMajors) {
+  if (!Array.isArray(config.consumerVersionSets)) {
+    throw new Error(`${compatConfigRelativePath} must define consumerVersionSets.`);
+  }
+
+  const versionSets = [...config.consumerVersionSets];
+  for (const major of [...supportedMajors].sort((left, right) => left - right)) {
+    upsertVersionSet(versionSets, {
+      angularMajor: major,
+      id: `angular-${major}-floor`,
+      mode: 'floor',
+    });
+    upsertVersionSet(versionSets, {
+      angularMajor: major,
+      id: `angular-${major}-latest`,
+      mode: 'latest',
+    });
+  }
+
+  versionSets.sort(compareVersionSets);
+  config.consumerVersionSets = versionSets;
+  config.buildAngularMajor = Math.max(
+    ...versionSets
+      .map((versionSet) => versionSet.angularMajor)
+      .filter((candidate) => Number.isInteger(candidate)),
+  );
+
+  return config;
+}
+
+function upsertVersionSet(versionSets, expected) {
+  const index = versionSets.findIndex((versionSet) => versionSet.id === expected.id);
+  if (index === -1) {
+    versionSets.push(expected);
+    return;
+  }
+
+  versionSets[index] = {
+    ...versionSets[index],
+    angularMajor: expected.angularMajor,
+    mode: expected.mode,
+  };
+}
+
+function compareVersionSets(left, right) {
+  const leftMajor = Number.isInteger(left.angularMajor)
+    ? left.angularMajor
+    : Number.MAX_SAFE_INTEGER;
+  const rightMajor = Number.isInteger(right.angularMajor)
+    ? right.angularMajor
+    : Number.MAX_SAFE_INTEGER;
+  if (leftMajor !== rightMajor) {
+    return leftMajor - rightMajor;
+  }
+
+  const leftMode = versionSetModeOrder.get(left.mode) ?? Number.MAX_SAFE_INTEGER;
+  const rightMode = versionSetModeOrder.get(right.mode) ?? Number.MAX_SAFE_INTEGER;
+  if (leftMode !== rightMode) {
+    return leftMode - rightMode;
+  }
+
+  return String(left.id).localeCompare(String(right.id));
+}
+
+function printResult({ changes, dryRun, major }) {
+  if (changes.length === 0) {
+    console.log(`Angular ${major} support is already configured.`);
+    return;
+  }
+
+  const heading = dryRun
+    ? `Dry run: would update Angular ${major} support in:`
+    : `Updated Angular ${major} support in:`;
+  console.log(heading);
+  for (const change of changes) {
+    console.log(`- ${change}`);
+  }
+}
+
+function printUsage() {
+  const scriptPath = relative(
+    process.cwd(),
+    fileURLToPath(import.meta.url),
+  );
+  console.log(
+    `Usage: node ${scriptPath} --major <major> [--workspace <path>] [--dry-run]`,
+  );
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}

--- a/.claude/skills/angular-version-support
+++ b/.claude/skills/angular-version-support
@@ -1,0 +1,1 @@
+../../.agents/skills/angular-version-support


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Adds a project-specific `angular-version-support` skill under `.agents/skills` and exposes it through `.claude/skills` with a relative symlink. The skill documents the deterministic Angular compatibility update workflow for this repo, adds OpenAI skill metadata, and includes a Node 22-compatible TypeScript helper for updating Angular peer ranges and the compatibility matrix without a runner.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Validation performed:

- `node --check .agents/skills/angular-version-support/scripts/add-angular-version.ts`
- Fixture update for Angular 20, including idempotent second run
- Real repo `--dry-run` with no tracked file changes
- Skill metadata/frontmatter checks
- `node --test tools/angular-compat/*.test.mjs`
- `pnpm run compat:assert`
- `pnpm run compat:matrix`
- `git diff --check`

Forward-tested the skill with a worker agent using the prompt to add Angular 20 support. That test validated the expected deterministic files and led to tightening the helper to backfill missing stable floor/latest rows.

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
