### PR TITLE
chore: add create-pr skill

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: create-pr
+description: Creates GitHub pull requests for this repo. Use when opening, drafting, publishing, or updating a pull request; enforces the repo PR template and Conventional Commits PR titles.
+---
+
+# Create PR
+
+Create pull requests with the repo's required title and description format.
+
+## Workflow
+
+1. Inspect the branch, diff, commits, and repo instructions before writing PR text.
+2. Read `.github/pull_request_template.md` and use it as the PR description structure.
+3. Write the PR title as a Conventional Commit: `type(optional-scope): imperative summary`.
+4. Fill every applicable PR template section with concrete details from the change.
+5. Keep template headings and checklists intact unless the user explicitly asks for a different format.
+6. Include exact validation commands in Testing and mark completed checklist items accurately.
+7. Call out UI media, operational impact, rollout, rollback, and reviewer notes when relevant.
+8. Create a ready-for-review PR with the prepared title and body unless the user explicitly requests a draft PR.
+9. After creation, verify the PR title and body match these requirements before handing back the link.
+
+## Title Rules
+
+- Use Conventional Commit types such as `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `build`, or `ci`.
+- Add a scope only when it clarifies the affected area.
+- Use a concise imperative summary with no trailing period.
+
+## Description Rules
+
+- Base the body on `.github/pull_request_template.md`, not an ad hoc summary.
+- Preserve required sections even when the entry is `N/A`.
+- For visible UI changes, include screenshots or video when available, or state why they are missing.
+- For Appwrite, migrations, native apps, deployment, env vars, or secrets, complete the Operational Impact checklist honestly.
+
+## Draft Rules
+
+- Default to a normal, ready-for-review PR.
+- Create a draft PR only when the user explicitly asks for draft status.

--- a/.agents/skills/create-pr/agents/openai.yaml
+++ b/.agents/skills/create-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Create PR'
+  short_description: 'Open PRs with repo conventions'
+  default_prompt: 'Use $create-pr to open a pull request for this branch.'

--- a/.claude/skills/create-pr
+++ b/.claude/skills/create-pr
@@ -1,0 +1,1 @@
+../../.agents/skills/create-pr


### PR DESCRIPTION
## PR Checklist

Adds the `create-pr` agent skill copied from the shop-together project so this repo can use the same PR authoring guidance for repository templates and Conventional Commit titles.

Closes N/A

## What is the new behavior?

- Adds `.agents/skills/create-pr` with the copied skill instructions and OpenAI interface metadata.
- Adds `.claude/skills/create-pr` as a symlink back to the shared `.agents` skill path.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

N/A - this only adds agent skill metadata and instructions.

## Other information

Validation:

- `cmp -s /Users/alfonso-andres/projects/shop-together/.agents/skills/create-pr/SKILL.md .agents/skills/create-pr/SKILL.md && cmp -s /Users/alfonso-andres/projects/shop-together/.agents/skills/create-pr/agents/openai.yaml .agents/skills/create-pr/agents/openai.yaml && echo "source copy verified"`
- `git show --stat --oneline --decorate HEAD`

No runtime package checks were run because this change only adds copied skill files and a symlink.

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

N/A