### PR TITLE
fix: update Angular support skill workspace guidance

### DIFF
--- a/.agents/skills/angular-version-support/SKILL.md
+++ b/.agents/skills/angular-version-support/SKILL.md
@@ -16,16 +16,20 @@ Before changing files, read
 1. Identify the requested Angular major from the user prompt.
    - If no target major is present, ask for the Angular major before mutating files.
    - Treat prompts like "Angular 20", "v20", and "major 20" as target major `20`.
-2. Use the deterministic helper when the task is to add a stable Angular major:
+2. Use the deterministic helper when the task is to add a stable Angular major
+   or move the workspace package manifests to that major:
 
    ```bash
    node .agents/skills/angular-version-support/scripts/add-angular-version.ts --major <major>
    ```
 
-   Use `--dry-run` before applying when the user asks for a preview.
-3. Audit the project-specific compatibility files listed in the reference.
-4. Run the focused validation commands from the reference.
-5. If general Angular coding changes are required, use `$angular-developer` after
+   Use `--dry-run` before applying when the user asks for a preview. Use
+   `--library-only` only when the user explicitly asks not to update demo/e2e
+   app manifests.
+3. Update the lockfile and any Angular-adjacent packages the helper calls out.
+4. Audit the project-specific compatibility files listed in the reference.
+5. Run the focused validation and workspace test commands from the reference.
+6. If general Angular coding changes are required, use `$angular-developer` after
    the compatibility matrix has been updated.
 
 ## Rules
@@ -33,7 +37,7 @@ Before changing files, read
 - Do not use Python for this skill's workflow or bundled scripts.
 - Keep bundled scripts executable with plain Node 22; do not require `tsx`,
   `ts-node`, build steps, or a custom runner.
-- Do not mass-upgrade demo app Angular dependency pins unless the user
-  explicitly asks for a workspace upgrade.
+- Update Angular package pins across workspace apps and packages by default so
+  the repo can install, build, and test against the requested Angular major.
 - Keep stable compatibility rows deterministic: one `floor` row and one
   `latest` row for every supported Angular major.

--- a/.agents/skills/angular-version-support/SKILL.md
+++ b/.agents/skills/angular-version-support/SKILL.md
@@ -27,9 +27,11 @@ Before changing files, read
    `--library-only` only when the user explicitly asks not to update demo/e2e
    app manifests.
 3. Update the lockfile and any Angular-adjacent packages the helper calls out.
-4. Audit the project-specific compatibility files listed in the reference.
-5. Run the focused validation and workspace test commands from the reference.
-6. If general Angular coding changes are required, use `$angular-developer` after
+4. Run official Angular migrations where possible before making manual code
+   fixes.
+5. Audit the project-specific compatibility files listed in the reference.
+6. Run the focused validation and workspace test commands from the reference.
+7. If general Angular coding changes are required, use `$angular-developer` after
    the compatibility matrix has been updated.
 
 ## Rules

--- a/.agents/skills/angular-version-support/SKILL.md
+++ b/.agents/skills/angular-version-support/SKILL.md
@@ -15,7 +15,8 @@ Before changing files, read
 
 1. Identify the requested Angular major from the user prompt.
    - If no target major is present, ask for the Angular major before mutating files.
-   - Treat prompts like "Angular 20", "v20", and "major 20" as target major `20`.
+   - Recognize forms like "Angular <major>", "v<major>", and
+     "major <major>".
 2. Use the deterministic helper when the task is to add a stable Angular major
    or move the workspace package manifests to that major:
 
@@ -33,6 +34,8 @@ Before changing files, read
 6. Run the focused validation and workspace test commands from the reference.
 7. If general Angular coding changes are required, use `$angular-developer` after
    the compatibility matrix has been updated.
+8. Report target-version-specific migration failures or fixes in your final
+   output. Add them to this skill only when they describe a durable repo rule.
 
 ## Rules
 
@@ -43,3 +46,5 @@ Before changing files, read
   the repo can install, build, and test against the requested Angular major.
 - Keep stable compatibility rows deterministic: one `floor` row and one
   `latest` row for every supported Angular major.
+- Keep the skill version-neutral. Do not bake in one-off findings from a single
+  target major unless they generalize across future Angular upgrades.

--- a/.agents/skills/angular-version-support/agents/openai.yaml
+++ b/.agents/skills/angular-version-support/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Angular Version Support"
-  short_description: "Update this repo's Angular support matrix"
+  short_description: "Update this repo's Angular support and apps"
   default_prompt: "Use $angular-version-support to add support for Angular 20."

--- a/.agents/skills/angular-version-support/agents/openai.yaml
+++ b/.agents/skills/angular-version-support/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Angular Version Support"
   short_description: "Update this repo's Angular support and apps"
-  default_prompt: "Use $angular-version-support to add support for Angular 20."
+  default_prompt: "Use $angular-version-support to add support for Angular <major>."

--- a/.agents/skills/angular-version-support/references/limitless-angular-compat.md
+++ b/.agents/skills/angular-version-support/references/limitless-angular-compat.md
@@ -66,6 +66,38 @@ Do not stop after the helper if any TypeScript, adapter, or lockfile updates
 are still required for the workspace to install and run tests on the requested
 Angular major.
 
+## Official Angular Migrations
+
+Prefer official Angular migrations before manual code edits. Angular supports
+update automation through `ng update`, and the CLI can run code migrations as
+part of an update.
+
+Use the Angular Update Guide for the current-to-target major pair, then run the
+CLI migrations where this repo has Angular projects:
+
+```bash
+rg --files -g angular.json apps packages
+```
+
+For each Angular app root with a local CLI available, run the relevant update
+or migration command from that app directory:
+
+```bash
+pnpm exec ng update @angular/cli@^<major> @angular/core@^<major>
+```
+
+If the helper already updated package manifests and you only need code
+migrations, run migration-only commands one package at a time:
+
+```bash
+pnpm exec ng update @angular/core --migrate-only --from <from> --to <target>
+pnpm exec ng update @angular/cli --migrate-only --from <from> --to <target>
+```
+
+Review and keep the generated changes when they are relevant. Do not replace
+official migrations with manual text edits unless no applicable migration is
+available or the migration fails and the failure is understood.
+
 After the deterministic edit, search for version-specific branches and stale
 contract text:
 

--- a/.agents/skills/angular-version-support/references/limitless-angular-compat.md
+++ b/.agents/skills/angular-version-support/references/limitless-angular-compat.md
@@ -66,6 +66,19 @@ Do not stop after the helper if any TypeScript, adapter, or lockfile updates
 are still required for the workspace to install and run tests on the requested
 Angular major.
 
+For Angular 20 upgrades in this repo, expect these follow-ups from prior
+verification:
+
+- `typescript-eslint` must support TypeScript 5.8+ when TypeScript moves with
+  Angular 20.
+- Code using `provideExperimentalZonelessChangeDetection` should migrate to
+  `provideZonelessChangeDetection`.
+- Do not add `@angular/animations` to `packages/sanity` only because Angular
+  platform-browser test imports expose a peer resolution failure. This package
+  should not gain new Angular framework dev dependencies unless source or tests
+  directly use them. Investigate test setup, adapters, and lockfile resolution
+  first, then report the exact failure if the fix is unclear.
+
 ## Official Angular Migrations
 
 Prefer official Angular migrations before manual code edits. Angular supports
@@ -79,24 +92,29 @@ CLI migrations where this repo has Angular projects:
 rg --files -g angular.json apps packages
 ```
 
-For each Angular app root with a local CLI available, run the relevant update
-or migration command from that app directory:
+Run app migrations from the workspace root with `pnpm --filter` so Volta and
+pnpm use the repo Node version. Verify the filtered command sees the repo Node:
 
 ```bash
-pnpm exec ng update @angular/cli@^<major> @angular/core@^<major>
+pnpm --filter <workspace-package-name> exec node -v
 ```
 
 If the helper already updated package manifests and you only need code
-migrations, run migration-only commands one package at a time:
+migrations, run migration-only commands one workspace package at a time. Include
+`--allow-dirty` because the helper and dependency updates make the worktree
+dirty before migrations run:
 
 ```bash
-pnpm exec ng update @angular/core --migrate-only --from <from> --to <target>
-pnpm exec ng update @angular/cli --migrate-only --from <from> --to <target>
+pnpm --filter <workspace-package-name> exec ng update @angular/core --migrate-only --from <from> --to <target> --allow-dirty
+pnpm --filter <workspace-package-name> exec ng update @angular/cli --migrate-only --from <from> --to <target> --allow-dirty
 ```
 
-Review and keep the generated changes when they are relevant. Do not replace
-official migrations with manual text edits unless no applicable migration is
-available or the migration fails and the failure is understood.
+This repo's app-local `angular.json` files may cause some Angular core
+migrations to resolve `../../tsconfig.base.json` incorrectly. If `ng update`
+fails with a tsconfig path error, record the failure, inspect the migration's
+targeted patterns, and manually audit/apply the relevant code changes. Do not
+replace official migrations with manual text edits unless no applicable
+migration is available or the migration fails and the failure is understood.
 
 After the deterministic edit, search for version-specific branches and stale
 contract text:

--- a/.agents/skills/angular-version-support/references/limitless-angular-compat.md
+++ b/.agents/skills/angular-version-support/references/limitless-angular-compat.md
@@ -66,18 +66,17 @@ Do not stop after the helper if any TypeScript, adapter, or lockfile updates
 are still required for the workspace to install and run tests on the requested
 Angular major.
 
-For Angular 20 upgrades in this repo, expect these follow-ups from prior
-verification:
+For every target major, treat validation failures as evidence to inspect the
+matching Angular release notes, official migrations, and dependency peer ranges.
+Update code and toolchain packages only when the target major requires it.
+Report target-specific findings in the final output or PR notes so the next
+skill revision can decide whether they are durable enough to encode here.
 
-- `typescript-eslint` must support TypeScript 5.8+ when TypeScript moves with
-  Angular 20.
-- Code using `provideExperimentalZonelessChangeDetection` should migrate to
-  `provideZonelessChangeDetection`.
-- Do not add `@angular/animations` to `packages/sanity` only because Angular
-  platform-browser test imports expose a peer resolution failure. This package
-  should not gain new Angular framework dev dependencies unless source or tests
-  directly use them. Investigate test setup, adapters, and lockfile resolution
-  first, then report the exact failure if the fix is unclear.
+Do not add new Angular framework dependencies to `packages/sanity` only to
+satisfy transitive peer resolution. Add a framework package only when source or
+tests directly import it, or when the repo intentionally broadens its Angular
+test surface. Otherwise investigate test setup, adapters, and lockfile
+resolution first, then report the exact failure if the fix is unclear.
 
 ## Official Angular Migrations
 

--- a/.agents/skills/angular-version-support/references/limitless-angular-compat.md
+++ b/.agents/skills/angular-version-support/references/limitless-angular-compat.md
@@ -2,8 +2,10 @@
 
 This workspace publishes `@limitless-angular/sanity` and verifies Angular
 support through the private `@limitless-angular/angular-compat` package.
-Adding support for a stable Angular major means updating the public peer range
-and the generated-consumer compatibility matrix.
+Adding support for a stable Angular major means updating the public peer range,
+the generated-consumer compatibility matrix, and every workspace app/package
+manifest that pins Angular packages so the repo can install, build, and test on
+that major.
 
 ## Required Files
 
@@ -17,6 +19,12 @@ and the generated-consumer compatibility matrix.
   - Add `angular-<major>-latest` with `mode: "latest"`.
   - Set `buildAngularMajor` to the newest stable major represented by
     `consumerVersionSets`.
+- Workspace `package.json` files with direct Angular toolchain dependencies
+  - Update direct `@angular/*` dependency and devDependency ranges.
+  - Update direct `@angular-devkit/*` devDependency ranges.
+  - Update direct `angular-eslint` and `ng-packagr` devDependency ranges.
+  - Update demo/e2e app manifests by default; they must run with the requested
+    Angular major unless the user explicitly asks for library-only support.
 
 Use the helper for this deterministic edit:
 
@@ -24,8 +32,9 @@ Use the helper for this deterministic edit:
 node .agents/skills/angular-version-support/scripts/add-angular-version.ts --major <major>
 ```
 
-The helper also backfills missing `floor`/`latest` rows for stable Angular
-majors that are already declared by the peer range or compatibility config.
+The helper also updates workspace Angular package pins and backfills missing
+`floor`/`latest` rows for stable Angular majors that are already declared by
+the peer range or compatibility config.
 
 For a preview:
 
@@ -33,7 +42,29 @@ For a preview:
 node .agents/skills/angular-version-support/scripts/add-angular-version.ts --major <major> --dry-run
 ```
 
+For explicit library-only support without demo/e2e app manifest upgrades:
+
+```bash
+node .agents/skills/angular-version-support/scripts/add-angular-version.ts --major <major> --library-only
+```
+
 ## Required Audit
+
+After the helper runs, update packages that require registry-specific
+compatibility decisions:
+
+- `typescript`: resolve the version range required by
+  `@angular/compiler-cli@<major>` and update all workspace manifests that pin
+  TypeScript.
+- Angular-adjacent adapters such as `@analogjs/vite-plugin-angular`,
+  `@analogjs/vitest-angular`, and `@testing-library/angular`: inspect current
+  peer compatibility and update when the requested Angular major requires it.
+- `pnpm-lock.yaml`: run `pnpm install` after package manifest edits so the
+  lockfile matches the workspace upgrade.
+
+Do not stop after the helper if any TypeScript, adapter, or lockfile updates
+are still required for the workspace to install and run tests on the requested
+Angular major.
 
 After the deterministic edit, search for version-specific branches and stale
 contract text:
@@ -59,21 +90,18 @@ Treat these as compatibility contract surfaces:
 Do not change these files only because a new major was added. Change them when
 tests reveal a contract drift or when the user asks to update the orchestration.
 
-## Demo App Pins
-
-The demo and e2e Angular apps currently pin their own Angular toolchains. Do
-not upgrade those app dependencies as part of "add Angular support" unless the
-user asks for a workspace or example-app upgrade. The compatibility harness
-builds and tests generated consumers separately from the demo apps.
-
 ## Validation
 
-Run focused validation after updating the support matrix:
+Run focused validation after updating the support matrix and workspace package
+manifests:
 
 ```bash
+pnpm install
 node --test tools/angular-compat/*.test.mjs
 pnpm run compat:assert
 pnpm run compat:matrix
+pnpm run build
+pnpm run test
 ```
 
 For real support changes, also run:

--- a/.agents/skills/angular-version-support/scripts/add-angular-version.ts
+++ b/.agents/skills/angular-version-support/scripts/add-angular-version.ts
@@ -256,7 +256,7 @@ function getWorkspaceAngularRange(dependency, range, major) {
   }
 
   if (dependency.startsWith('@angular/')) {
-    return withExistingRangePrefix(range, `${major}.0.0`, '~');
+    return `~${major}.0.0`;
   }
 
   if (dependency === 'angular-eslint') {

--- a/.agents/skills/angular-version-support/scripts/add-angular-version.ts
+++ b/.agents/skills/angular-version-support/scripts/add-angular-version.ts
@@ -1,4 +1,10 @@
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -10,6 +16,16 @@ const angularPeerDependencies = [
   '@angular/core',
   '@angular/router',
 ];
+const dependencyFields = ['dependencies', 'devDependencies'];
+const ignoredWorkspaceDirectories = new Set([
+  '.angular',
+  '.compat',
+  '.git',
+  '.turbo',
+  'coverage',
+  'dist',
+  'node_modules',
+]);
 const versionSetModeOrder = new Map([
   ['floor', 0],
   ['latest', 1],
@@ -34,12 +50,22 @@ function main() {
     supportedMajors.add(major);
 
     const changes = [];
-    updateJsonFile(
-      workspaceRoot,
-      sanityPackageRelativePath,
-      (packageJson) => updateSanityPeerDependencies(packageJson, supportedMajors),
-      { changes, dryRun: args.dryRun },
-    );
+    const packageJsonPaths = args.libraryOnly
+      ? [sanityPackageRelativePath]
+      : findPackageJsonFiles(workspaceRoot);
+    for (const packageJsonPath of packageJsonPaths) {
+      updateJsonFile(
+        workspaceRoot,
+        packageJsonPath,
+        (packageJson) => updateWorkspacePackageJson(
+          packageJson,
+          packageJsonPath,
+          major,
+          supportedMajors,
+        ),
+        { changes, dryRun: args.dryRun },
+      );
+    }
     updateJsonFile(
       workspaceRoot,
       compatConfigRelativePath,
@@ -47,7 +73,12 @@ function main() {
       { changes, dryRun: args.dryRun },
     );
 
-    printResult({ changes, dryRun: args.dryRun, major });
+    printResult({
+      changes,
+      dryRun: args.dryRun,
+      libraryOnly: args.libraryOnly,
+      major,
+    });
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));
     process.exitCode = 1;
@@ -58,6 +89,7 @@ function parseArgs(argv) {
   const args = {
     dryRun: false,
     help: false,
+    libraryOnly: false,
     major: undefined,
     workspace: undefined,
   };
@@ -72,6 +104,11 @@ function parseArgs(argv) {
 
     if (value === '--help' || value === '-h') {
       args.help = true;
+      continue;
+    }
+
+    if (value === '--library-only') {
+      args.libraryOnly = true;
       continue;
     }
 
@@ -184,6 +221,92 @@ function updateSanityPeerDependencies(packageJson, supportedMajors) {
   }
 
   return packageJson;
+}
+
+function updateWorkspacePackageJson(
+  packageJson,
+  relativePath,
+  major,
+  supportedMajors,
+) {
+  if (relativePath === sanityPackageRelativePath) {
+    updateSanityPeerDependencies(packageJson, supportedMajors);
+  }
+
+  for (const field of dependencyFields) {
+    const dependencies = packageJson[field];
+    if (!dependencies || typeof dependencies !== 'object') {
+      continue;
+    }
+
+    for (const [dependency, range] of Object.entries(dependencies)) {
+      const nextRange = getWorkspaceAngularRange(dependency, range, major);
+      if (nextRange) {
+        dependencies[dependency] = nextRange;
+      }
+    }
+  }
+
+  return packageJson;
+}
+
+function getWorkspaceAngularRange(dependency, range, major) {
+  if (dependency.startsWith('@angular-devkit/')) {
+    return withExistingRangePrefix(range, `0.${major}00.0`, '~');
+  }
+
+  if (dependency.startsWith('@angular/')) {
+    return withExistingRangePrefix(range, `${major}.0.0`, '~');
+  }
+
+  if (dependency === 'angular-eslint') {
+    return withExistingRangePrefix(range, `${major}.0.0`, '^');
+  }
+
+  if (dependency === 'ng-packagr') {
+    return withExistingRangePrefix(range, `${major}.0.0`, '~');
+  }
+
+  return undefined;
+}
+
+function withExistingRangePrefix(range, version, defaultPrefix) {
+  const prefix = String(range).trim().match(/^([~^])?\d/)?.[1];
+  if (prefix) {
+    return `${prefix}${version}`;
+  }
+
+  if (/^\d/.test(String(range).trim())) {
+    return version;
+  }
+
+  return `${defaultPrefix}${version}`;
+}
+
+function findPackageJsonFiles(workspaceRoot) {
+  const paths = [];
+  collectPackageJsonFiles(workspaceRoot, workspaceRoot, paths);
+  return paths.sort();
+}
+
+function collectPackageJsonFiles(workspaceRoot, directory, paths) {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (!ignoredWorkspaceDirectories.has(entry.name)) {
+        collectPackageJsonFiles(workspaceRoot, join(directory, entry.name), paths);
+      }
+      continue;
+    }
+
+    if (entry.name !== 'package.json') {
+      continue;
+    }
+
+    const path = join(directory, entry.name);
+    if (statSync(path).isFile()) {
+      paths.push(relative(workspaceRoot, path));
+    }
+  }
 }
 
 function readSupportedAngularMajors(workspaceRoot) {
@@ -304,7 +427,7 @@ function compareVersionSets(left, right) {
   return String(left.id).localeCompare(String(right.id));
 }
 
-function printResult({ changes, dryRun, major }) {
+function printResult({ changes, dryRun, libraryOnly, major }) {
   if (changes.length === 0) {
     console.log(`Angular ${major} support is already configured.`);
     return;
@@ -317,6 +440,12 @@ function printResult({ changes, dryRun, major }) {
   for (const change of changes) {
     console.log(`- ${change}`);
   }
+
+  if (!libraryOnly) {
+    console.log(
+      'Next: update TypeScript and Angular-adjacent adapter ranges as needed, run pnpm install, then run the validation commands from the skill reference.',
+    );
+  }
 }
 
 function printUsage() {
@@ -325,7 +454,7 @@ function printUsage() {
     fileURLToPath(import.meta.url),
   );
   console.log(
-    `Usage: node ${scriptPath} --major <major> [--workspace <path>] [--dry-run]`,
+    `Usage: node ${scriptPath} --major <major> [--workspace <path>] [--dry-run] [--library-only]`,
   );
 }
 


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #

## What is the new behavior?

Updates the `angular-version-support` skill so adding Angular support defaults to moving workspace Angular package manifests, not only the library peer range and compatibility matrix.

The helper now scans workspace `package.json` files and updates direct Angular toolchain dependencies in apps/packages, while keeping `--library-only` available for explicit library-only support. The skill reference now instructs agents to resolve TypeScript and Angular-adjacent adapter compatibility, update the lockfile, and run workspace build/test validation after the deterministic helper step.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Validation performed:

- `node --check .agents/skills/angular-version-support/scripts/add-angular-version.ts`
- `node .agents/skills/angular-version-support/scripts/add-angular-version.ts --major 20 --dry-run`
- `node .agents/skills/angular-version-support/scripts/add-angular-version.ts --major 20 --dry-run --library-only`
- Fixture run validating app/package Angular range updates
- `node --test tools/angular-compat/*.test.mjs`
- `pnpm run compat:assert`
- `pnpm run compat:matrix`
- `git diff --check`

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
