### PR TITLE
docs(sanity): clarify Angular compatibility table

### DIFF
--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -29,10 +29,12 @@ npm install --save @limitless-angular/sanity
 
 ### Version Compatibility
 
-| Angular version | Package version |
-| --------------- | --------------- |
-| 18.x            | 18.x            |
-| ≥18.0.0         | 19.x            |
+| Angular | `@limitless-angular/sanity` |
+| ------- | --------------------------- |
+| 19.x    | 19.x                        |
+| 18.x    | 19.x, 18.x                  |
+
+The current 19.x package line supports Angular 18 and Angular 19.
 
 ## Quick Start
 


### PR DESCRIPTION
## PR Checklist

Clarifies the published Angular compatibility table for `@limitless-angular/sanity` so readers can see which library major supports each Angular major.

Closes N/A

## What is the new behavior?

- Replaces the ambiguous `>=18.0.0` compatibility row with a compact Angular-to-library matrix.
- Calls out that the current 19.x package line supports Angular 18 and Angular 19.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

N/A; this is a documentation-only change.

## Other information

Validation:

- `git diff --check`
- `node --test tools/angular-compat/*.test.mjs`
- `pnpm run compat:assert`
- `pnpm run compat:matrix`

Operational impact: documentation-only change; no runtime, package, or release behavior changed.

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

N/A