### PR TITLE
fix(release): align repository url for npm trust

### DIFF
--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/limitless-angular/limitless-angular.git"
+    "url": "https://github.com/limitless-angular/limitless-angular"
   },
   "bugs": {
     "url": "https://github.com/limitless-angular/limitless-angular/issues"

--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -76,4 +76,6 @@ before publishing.
 The npm package must trust the GitHub Actions publisher for
 `limitless-angular/limitless-angular`, workflow `release-and-publish.yml`, and
 environment `npm-release`; the publish job uses npm trusted publishing instead
-of a long-lived npm token.
+of a long-lived npm token. The package `repository.url` must exactly match
+`https://github.com/limitless-angular/limitless-angular` so npm can match the
+OIDC publisher to the package metadata.

--- a/tools/release/src/pipeline.test.mjs
+++ b/tools/release/src/pipeline.test.mjs
@@ -217,7 +217,18 @@ function createReleaseFixture() {
 
   writeFileSync(
     packageJsonPath,
-    `${JSON.stringify({ name: '@limitless-angular/sanity', version: '1.0.0' }, null, 2)}\n`,
+    `${JSON.stringify(
+      {
+        name: '@limitless-angular/sanity',
+        repository: {
+          type: 'git',
+          url: 'https://github.com/limitless-angular/limitless-angular',
+        },
+        version: '1.0.0',
+      },
+      null,
+      2,
+    )}\n`,
   );
   writeFileSync(changelogPath, '## 1.0.0\n');
 

--- a/tools/release/src/plan.mjs
+++ b/tools/release/src/plan.mjs
@@ -18,6 +18,7 @@ export function createReleasePlan(options = {}) {
   const commandCapture = options.capture ?? defaultCapture;
   const packageJson = readJson(paths.packageJsonPath);
   const currentVersion = packageJson.version;
+  const packageRepositoryUrl = getRepositoryUrl(packageJson.repository);
   const latestTag = getLatestTag(currentVersion, {
     capture: commandCapture,
     releaseTagPrefix: options.releaseTagPrefix ?? releaseTagPrefix,
@@ -59,6 +60,7 @@ export function createReleasePlan(options = {}) {
     nextVersion,
     npmDistTag: isPrerelease ? prereleaseNpmDistTag : stableNpmDistTag,
     packageName: packageJson.name,
+    packageRepositoryUrl,
     paths,
     prerelease: isPrerelease,
     releaseTag,
@@ -104,6 +106,14 @@ function resolveReleasePaths(paths = {}) {
     changelogPath: paths.changelogPath ?? changelogPath,
     packageJsonPath: paths.packageJsonPath ?? packageJsonPath,
   };
+}
+
+function getRepositoryUrl(repository) {
+  if (typeof repository === 'string') {
+    return repository;
+  }
+
+  return repository?.url;
 }
 
 function resolveVersionSpecifier(currentVersion, specifier, options = {}) {

--- a/tools/release/src/plan.test.mjs
+++ b/tools/release/src/plan.test.mjs
@@ -71,6 +71,10 @@ test('release plan infers the next version from conventional commits', () => {
     assert.equal(plan.currentVersion, '1.0.0');
     assert.equal(plan.nextVersion, '1.1.0');
     assert.equal(plan.npmDistTag, 'latest');
+    assert.equal(
+      plan.packageRepositoryUrl,
+      'https://github.com/limitless-angular/limitless-angular',
+    );
     assert.equal(plan.prerelease, false);
     assert.equal(plan.releaseTag, 'sanity@1.1.0');
     assert.match(plan.changelogSection, /## 1\.1\.0 \(2026-06-08\)/);
@@ -135,7 +139,18 @@ function createReleaseFixture({ version = '1.0.0' } = {}) {
 
   writeFileSync(
     packageJsonPath,
-    `${JSON.stringify({ name: '@limitless-angular/sanity', version }, null, 2)}\n`,
+    `${JSON.stringify(
+      {
+        name: '@limitless-angular/sanity',
+        repository: {
+          type: 'git',
+          url: 'https://github.com/limitless-angular/limitless-angular',
+        },
+        version,
+      },
+      null,
+      2,
+    )}\n`,
   );
   writeFileSync(changelogPath, '## 1.0.0\n');
 

--- a/tools/release/src/preflight.mjs
+++ b/tools/release/src/preflight.mjs
@@ -1,4 +1,5 @@
 import { capture as defaultCapture, run as defaultRun } from './commands.mjs';
+import { repoUrl } from './config.mjs';
 
 const defaultReleaseBranch = 'main';
 const npmRegistry = 'https://registry.npmjs.org';
@@ -11,6 +12,7 @@ export function assertPublishPreconditions(plan, options = {}) {
 
   assertGitHubReleaseToken(env);
   assertReleaseRef({ capture: commandCapture, env, releaseBranch });
+  assertTrustedPublishingRepository(plan);
   assertCleanWorktree(commandCapture);
   syncReleaseBranch(commandRun, releaseBranch);
   assertHeadMatchesRemote(commandCapture, releaseBranch);
@@ -60,6 +62,14 @@ function assertReleaseRef({ capture, env, releaseBranch }) {
   if (currentBranch !== releaseBranch) {
     throw new Error(
       `Refusing to publish from branch ${currentBranch || 'detached HEAD'}; expected ${releaseBranch}.`,
+    );
+  }
+}
+
+function assertTrustedPublishingRepository(plan) {
+  if (plan.packageRepositoryUrl !== repoUrl) {
+    throw new Error(
+      `Refusing to publish because package repository.url ${formatValue(plan.packageRepositoryUrl)} must exactly match ${repoUrl} for npm trusted publishing.`,
     );
   }
 }
@@ -166,6 +176,10 @@ function normalizeNpmVersions(value) {
   }
 
   return value ? [value] : [];
+}
+
+function formatValue(value) {
+  return value ? JSON.stringify(value) : 'is missing';
 }
 
 function commandSucceeds(capture, command, args) {

--- a/tools/release/src/preflight.test.mjs
+++ b/tools/release/src/preflight.test.mjs
@@ -9,6 +9,8 @@ import {
 const plan = {
   nextVersion: '1.1.0',
   packageName: '@limitless-angular/sanity',
+  packageRepositoryUrl:
+    'https://github.com/limitless-angular/limitless-angular',
   releaseTag: 'sanity@1.1.0',
 };
 
@@ -45,6 +47,25 @@ test('publish preflight rejects dirty worktrees', () => {
         run: recordRun(),
       }),
     /uncommitted workspace changes/,
+  );
+});
+
+test('publish preflight rejects repository URLs that cannot satisfy npm trust', () => {
+  assert.throws(
+    () =>
+      assertPublishPreconditions(
+        {
+          ...plan,
+          packageRepositoryUrl:
+            'git+https://github.com/limitless-angular/limitless-angular.git',
+        },
+        {
+          capture: createCapture(),
+          env: { GITHUB_REF: 'refs/heads/main', GITHUB_TOKEN: 'token' },
+          run: recordRun(),
+        },
+      ),
+    /repository\.url .* must exactly match .* npm trusted publishing/,
   );
 });
 


### PR DESCRIPTION
## PR Checklist

The trusted-publishing release job reached `npm publish` but npm returned `ENEEDAUTH`. npm trusted-publisher troubleshooting requires the package `repository.url` to exactly match the GitHub repository, and `@limitless-angular/sanity` still used the legacy `git+https://...git` URL.

Closes #

## What is the new behavior?

`packages/sanity/package.json` now uses the exact GitHub repository URL expected by npm trusted publishing: `https://github.com/limitless-angular/limitless-angular`.

The release plan now carries the package repository URL, and publish preflight rejects repository metadata that cannot satisfy npm trusted publishing before the release job commits, tags, or attempts `npm publish`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validation run locally:

- `pnpm --filter=@limitless-angular/release-tools test`
- `pnpm exec prettier --check packages/sanity/package.json tools/release/src/plan.mjs tools/release/src/preflight.mjs tools/release/src/preflight.test.mjs tools/release/src/plan.test.mjs tools/release/src/pipeline.test.mjs tools/release/README.md`
- `git diff --check`

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?
