### PR TITLE
chore(angular): enable zoneless app defaults

### DIFF
--- a/apps/analog-sanity-blog-example/src/app/app.config.ts
+++ b/apps/analog-sanity-blog-example/src/app/app.config.ts
@@ -1,5 +1,6 @@
 import {
   type ApplicationConfig,
+  provideBrowserGlobalErrorListeners,
   provideEnvironmentInitializer,
   provideZonelessChangeDetection,
 } from '@angular/core';
@@ -19,6 +20,7 @@ import { updateMetaTagsOnRouteChange } from './utils/meta-tags';
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZonelessChangeDetection(),
+    provideBrowserGlobalErrorListeners(),
     provideFileRouter(
       withComponentInputBinding(),
       withNavigationErrorHandler(console.error),

--- a/apps/analog-sanity-blog-example/src/app/utils/meta-tags.ts
+++ b/apps/analog-sanity-blog-example/src/app/utils/meta-tags.ts
@@ -43,7 +43,6 @@ export function updateMetaTagsOnRouteChange(): void {
   router.events
     .pipe(filter((event) => event instanceof NavigationEnd))
     .subscribe(async () => {
-      // For some reason setTitle and updateTag doesn't work with zone.js activated
       const snapshot = router.routerState.snapshot;
       const metaTagMap = await getMetaTagMap(snapshot.root, snapshot);
       for (const metaTagSelector in metaTagMap) {

--- a/apps/analog-sanity-blog-example/tsconfig.json
+++ b/apps/analog-sanity-blog-example/tsconfig.json
@@ -25,6 +25,7 @@
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictStandalone": true,
+    "typeCheckHostBindings": true,
     "strictTemplates": true
   }
 }

--- a/apps/sanity-example/src/app/app.config.server.ts
+++ b/apps/sanity-example/src/app/app.config.server.ts
@@ -1,10 +1,11 @@
 import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
-import { provideServerRendering } from '@angular/platform-server';
+import { provideServerRendering, withRoutes } from '@angular/ssr';
 
 import { appConfig } from './app.config';
+import { serverRoutes } from './app.routes.server';
 
 const serverConfig: ApplicationConfig = {
-  providers: [provideServerRendering()],
+  providers: [provideServerRendering(withRoutes(serverRoutes))],
 };
 
 export const config = mergeApplicationConfig(appConfig, serverConfig);

--- a/apps/sanity-example/src/app/app.config.ts
+++ b/apps/sanity-example/src/app/app.config.ts
@@ -1,5 +1,6 @@
 import {
   ApplicationConfig,
+  provideBrowserGlobalErrorListeners,
   provideZonelessChangeDetection,
 } from '@angular/core';
 import { provideRouter } from '@angular/router';
@@ -14,6 +15,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideClientHydration(withEventReplay()),
     provideZonelessChangeDetection(),
+    provideBrowserGlobalErrorListeners(),
     provideRouter(appRoutes),
   ],
 };

--- a/apps/sanity-example/src/app/app.routes.server.ts
+++ b/apps/sanity-example/src/app/app.routes.server.ts
@@ -1,0 +1,8 @@
+import { RenderMode, type ServerRoute } from '@angular/ssr';
+
+export const serverRoutes: ServerRoute[] = [
+  {
+    path: '**',
+    renderMode: RenderMode.Server,
+  },
+];

--- a/apps/sanity-example/tsconfig.json
+++ b/apps/sanity-example/tsconfig.json
@@ -26,6 +26,7 @@
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictStandalone": true,
+    "typeCheckHostBindings": true,
     "strictTemplates": true
   }
 }

--- a/apps/sanity-presentation-e2e-preview/angular.json
+++ b/apps/sanity-presentation-e2e-preview/angular.json
@@ -19,7 +19,7 @@
             "outputPath": "dist/sanity-presentation-e2e-preview",
             "index": "src/index.html",
             "browser": "src/main.ts",
-            "polyfills": ["zone.js"],
+            "polyfills": [],
             "tsConfig": "tsconfig.app.json",
             "assets": [
               {

--- a/apps/sanity-presentation-e2e-preview/package.json
+++ b/apps/sanity-presentation-e2e-preview/package.json
@@ -21,8 +21,7 @@
     "@sanity/client": "^7.22.1",
     "express": "^4.18.2",
     "rxjs": "~7.8.0",
-    "tslib": "^2.3.0",
-    "zone.js": "~0.15.0"
+    "tslib": "^2.3.0"
   },
   "devDependencies": {
     "@angular/build": "~20.0.0",

--- a/apps/sanity-presentation-e2e-preview/src/app/app.config.server.ts
+++ b/apps/sanity-presentation-e2e-preview/src/app/app.config.server.ts
@@ -1,9 +1,10 @@
 import { ApplicationConfig, mergeApplicationConfig } from '@angular/core';
-import { provideServerRendering } from '@angular/platform-server';
+import { provideServerRendering, withRoutes } from '@angular/ssr';
 import { appConfig } from './app.config';
+import { serverRoutes } from './app.routes.server';
 
 const serverConfig: ApplicationConfig = {
-  providers: [provideServerRendering()],
+  providers: [provideServerRendering(withRoutes(serverRoutes))],
 };
 
 export const config = mergeApplicationConfig(appConfig, serverConfig);

--- a/apps/sanity-presentation-e2e-preview/src/app/app.config.ts
+++ b/apps/sanity-presentation-e2e-preview/src/app/app.config.ts
@@ -1,4 +1,8 @@
-import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import {
+  ApplicationConfig,
+  provideBrowserGlobalErrorListeners,
+  provideZonelessChangeDetection,
+} from '@angular/core';
 import {
   provideClientHydration,
   withEventReplay,
@@ -9,7 +13,8 @@ import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideZonelessChangeDetection(),
+    provideBrowserGlobalErrorListeners(),
     provideRouter(routes),
     provideClientHydration(withEventReplay()),
   ],

--- a/apps/sanity-presentation-e2e-preview/src/app/app.routes.server.ts
+++ b/apps/sanity-presentation-e2e-preview/src/app/app.routes.server.ts
@@ -1,0 +1,8 @@
+import { RenderMode, type ServerRoute } from '@angular/ssr';
+
+export const serverRoutes: ServerRoute[] = [
+  {
+    path: '**',
+    renderMode: RenderMode.Server,
+  },
+];

--- a/apps/sanity-presentation-e2e-preview/tsconfig.json
+++ b/apps/sanity-presentation-e2e-preview/tsconfig.json
@@ -26,6 +26,7 @@
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictStandalone": true,
+    "typeCheckHostBindings": true,
     "strictTemplates": true
   }
 }

--- a/packages/sanity/tsconfig.json
+++ b/packages/sanity/tsconfig.json
@@ -24,6 +24,7 @@
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
+    "typeCheckHostBindings": true,
     "strictTemplates": true
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,9 +371,6 @@ importers:
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
-      zone.js:
-        specifier: ~0.15.0
-        version: 0.15.0
     devDependencies:
       '@angular/build':
         specifier: ~20.0.0
@@ -29113,7 +29110,8 @@ snapshots:
 
   zod@4.4.3: {}
 
-  zone.js@0.15.0: {}
+  zone.js@0.15.0:
+    optional: true
 
   zustand@5.0.14(@types/react@19.2.17)(immer@10.2.0)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
     optionalDependencies:

--- a/tools/angular-compat/lib.mjs
+++ b/tools/angular-compat/lib.mjs
@@ -372,10 +372,6 @@ export function resolveAngularToolchain(versionSetOrMajor, options = {}) {
     `@angular/compiler-cli@${compilerCliVersion}`,
     'peerDependencies',
   );
-  const corePeers = resolverOptions.resolveNpmJson(
-    `@angular/core@${angularVersion}`,
-    'peerDependencies',
-  );
   const angularBuildVersion = options.includeCli
     ? resolveAngularPackageVersion(
         '@angular/build',
@@ -424,9 +420,6 @@ export function resolveAngularToolchain(versionSetOrMajor, options = {}) {
     typescriptRange,
     resolverOptions,
   );
-  const zoneVersion = corePeers['zone.js']
-    ? resolveLatestSatisfying('zone.js', corePeers['zone.js'], resolverOptions)
-    : undefined;
 
   return {
     id: versionSet.id,
@@ -438,7 +431,6 @@ export function resolveAngularToolchain(versionSetOrMajor, options = {}) {
     cliVersion,
     ngPackagrVersion,
     typescriptVersion,
-    zoneVersion,
   };
 }
 

--- a/tools/angular-compat/lib.test.mjs
+++ b/tools/angular-compat/lib.test.mjs
@@ -46,16 +46,12 @@ test('canary toolchain allows framework and CLI next tags to move independently'
     '@angular/compiler-cli@22.1.0-next.0 peerDependencies': {
       typescript: '>=6.0 <6.2',
     },
-    '@angular/core@22.1.0-next.0 peerDependencies': {
-      'zone.js': '^0.16.0',
-    },
     '@angular/build@next version': '22.0.0',
     '@angular/build@22.0.0 peerDependencies': {
       typescript: '>=6.0 <6.1',
     },
     '@angular/cli@next version': '22.0.0',
     'typescript versions': ['6.0.0', '6.0.1', '6.1.0'],
-    'zone.js versions': ['0.15.0', '0.16.0'],
   });
 
   const toolchain = resolveAngularToolchain(
@@ -68,7 +64,6 @@ test('canary toolchain allows framework and CLI next tags to move independently'
   assert.equal(toolchain.angularBuildVersion, '22.0.0');
   assert.equal(toolchain.cliVersion, '22.0.0');
   assert.equal(toolchain.typescriptVersion, '6.0.1');
-  assert.equal(toolchain.zoneVersion, '0.16.0');
   assert.equal(
     calls.some(({ spec }) => spec === '@angular/build@22.1.0-next.0'),
     false,

--- a/tools/angular-compat/test-consumer.mjs
+++ b/tools/angular-compat/test-consumer.mjs
@@ -101,7 +101,6 @@ function writeConsumerProject(
     '@sanity/image-url': packageJson.peerDependencies['@sanity/image-url'],
     rxjs: packageJson.peerDependencies.rxjs,
     tslib: packageJson.dependencies.tslib,
-    'zone.js': toolchain.zoneVersion,
   };
 
   writePnpmWorkspaceConfig(workspace, ['.']);
@@ -150,7 +149,7 @@ function writeConsumerProject(
               outputPath: `dist/${packageName}`,
               index: 'src/index.html',
               browser: 'src/main.ts',
-              polyfills: ['zone.js'],
+              polyfills: [],
               tsConfig: 'tsconfig.app.json',
               inlineStyleLanguage: 'css',
               assets: [],
@@ -193,6 +192,7 @@ function writeConsumerProject(
       enableI18nLegacyMessageIdFormat: false,
       strictInjectionParameters: true,
       strictInputAccessModifiers: true,
+      typeCheckHostBindings: true,
       strictTemplates: true,
     },
   });
@@ -227,7 +227,7 @@ function writeConsumerProject(
   writeFileSync(join(workspace, 'src/styles.css'), '');
   writeFileSync(join(workspace, 'src/entrypoints.ts'), entrypointsSource());
   writeFileSync(join(workspace, 'src/api-types.ts'), apiTypesSource());
-  writeFileSync(join(workspace, 'src/main.ts'), consumerMainSource());
+  writeFileSync(join(workspace, 'src/main.ts'), consumerMainSource(toolchain));
   writeFileSync(
     join(workspace, 'runtime-server.mjs'),
     runtimeServerSource(packageName, runtimePort),
@@ -254,8 +254,22 @@ function entrypointsSource() {
     .join('\n');
 }
 
-function consumerMainSource() {
-  return `import { Component } from '@angular/core';
+function consumerMainSource(toolchain) {
+  const zonelessProvider =
+    toolchain.angularMajor >= 20
+      ? 'provideZonelessChangeDetection'
+      : 'provideExperimentalZonelessChangeDetection';
+  const coreImports = ['Component', zonelessProvider];
+  const browserGlobalErrorProvider =
+    toolchain.angularMajor >= 20
+      ? '\n    provideBrowserGlobalErrorListeners(),'
+      : '';
+
+  if (toolchain.angularMajor >= 20) {
+    coreImports.push('provideBrowserGlobalErrorListeners');
+  }
+
+  return `import { ${coreImports.join(', ')} } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
 
 import { provideSanity } from '@limitless-angular/sanity';
@@ -313,6 +327,7 @@ class AppComponent {
 
 bootstrapApplication(AppComponent, {
   providers: [
+    ${zonelessProvider}(),${browserGlobalErrorProvider}
     provideSanity(sanityConfig),
     provideSanityLoader(sanityConfig),
   ],


### PR DESCRIPTION
## PR Checklist

Closes #

## What is the new behavior?

This updates the Angular app defaults for the current Angular 20 setup:

- Adds `provideBrowserGlobalErrorListeners()` to the Angular app configs.
- Converts the presentation preview app from Zone-based change detection to `provideZonelessChangeDetection()` and removes its direct `zone.js` dependency/polyfill.
- Adds explicit route-level `RenderMode.Server` server routes for the CLI Angular SSR apps (`sanity-example` and `sanity-presentation-e2e-preview`).
- Enables `typeCheckHostBindings` for the Angular app/package tsconfigs and the generated compatibility consumer.
- Updates compatibility tooling so generated consumers run zoneless across Angular 18/19/20 without a direct `zone.js` dependency.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

No migration is required. The CLI SSR apps keep dynamic server rendering by using `RenderMode.Server` for all server routes.

## Other information

Validation:

- `pnpm build`
- `pnpm test`
- `pnpm lint`
- `pnpm compat:pack`
- `pnpm compat:test --set angular-18-floor --skip-runtime`
- `pnpm compat:test --set angular-20-latest --skip-runtime`

Notes:

- `zone.js` is no longer referenced by repo source/app config outside the lockfile's optional transitive peer resolution.

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

N/A
