### PR TITLE
chore(release): reconcile published 20.0.0-next.0

### DIFF
--- a/packages/sanity/CHANGELOG.md
+++ b/packages/sanity/CHANGELOG.md
@@ -1,3 +1,40 @@
+## 20.0.0-next.0 (2026-06-14)
+
+### 🚀 Features
+
+- add Angular version support skill (#52) ([1a54aec](https://github.com/limitless-angular/limitless-angular/commit/1a54aec8c3a00da553187d8f143bb2229656e6de))
+- align portabletext with react v6.2.0 (#44) ([933a643](https://github.com/limitless-angular/limitless-angular/commit/933a6434a575b67e5d9ffea21f7049555edf2a59))
+- support next prereleases (#45) ([5df94bf](https://github.com/limitless-angular/limitless-angular/commit/5df94bfc1e00fd0e6c5f74577dad59ef87fb5b0b))
+- align preview kit with v6.2.0 (#43) ([f86f34b](https://github.com/limitless-angular/limitless-angular/commit/f86f34b84656db4198e4012358ca1c037fd154bb))
+- add visual editing 5.4.3 parity (#42) ([b3258bc](https://github.com/limitless-angular/limitless-angular/commit/b3258bcdc1266ffcdf460ca1a043259b1afd86d5))
+- align preview kit with upstream v5.2.6 (#41) ([5dc0695](https://github.com/limitless-angular/limitless-angular/commit/5dc0695f3332e6ff1ad6ab9a53d17276d7d775d8))
+- add analog blog studio workflow (#39) ([6a8c765](https://github.com/limitless-angular/limitless-angular/commit/6a8c765811d9186de7b89164ddf0c7bfcf646456))
+- add dry-run validation pipeline (#38) ([08bfe06](https://github.com/limitless-angular/limitless-angular/commit/08bfe0619357168a58016e0779bbb26d8e82809a))
+- widen supported sanity dependency majors (#36) ([1a64d22](https://github.com/limitless-angular/limitless-angular/commit/1a64d2276031e49344a97ea80e9fb6e4271e240e))
+- add angular compatibility harness (#27) ([ffc05db](https://github.com/limitless-angular/limitless-angular/commit/ffc05db5afd2f344f5c1f74258dd3b197476457c))
+- unknown components and reduce template logic (#13) ([26b6b3b](https://github.com/limitless-angular/limitless-angular/commit/26b6b3b4683a0a93f186cedaacb69f29365895ce))
+
+### 🩹 Fixes
+
+- pass trusted publishing env through turbo (#60) ([c93b7e1](https://github.com/limitless-angular/limitless-angular/commit/c93b7e1c08182b2b3e08d5c13b5a87be8bdcca26))
+- align repository url for npm trust (#58) ([acec4d8](https://github.com/limitless-angular/limitless-angular/commit/acec4d83ac938f7fb9eb5abdd60f05a6f7cb0d38))
+- update Angular support skill workspace guidance (#55) ([4a999d8](https://github.com/limitless-angular/limitless-angular/commit/4a999d84847073756465205d2610b02fc370a7b9))
+- show planned versions in summaries (#47) ([a242af8](https://github.com/limitless-angular/limitless-angular/commit/a242af80f5e30f4089f3152d319fa2d0598285e2))
+- resolve Angular CLI canaries by dist-tag (#46) ([75f5b5a](https://github.com/limitless-angular/limitless-angular/commit/75f5b5a9a75f7d0a307eba5dc34d7aa081c76617))
+- let Playwright own Studio servers (#40) ([19e0b01](https://github.com/limitless-angular/limitless-angular/commit/19e0b0138dcc0cb3d1773f57f1fb27b6bc80abae))
+- pin pnpm engine node version (#31) ([b3707ff](https://github.com/limitless-angular/limitless-angular/commit/b3707ff64ab649245783a74be613795773aa2684))
+- pin volta runtime for setup (#30) ([26d6cbf](https://github.com/limitless-angular/limitless-angular/commit/26d6cbfa2fda2769d7eeb6925cc2cf70a2c821cf))
+- restore sanity example deployment (#29) ([efa1f18](https://github.com/limitless-angular/limitless-angular/commit/efa1f18d01a3aea805ea56745513947984449412))
+- keep analog example dist package-local (#23) ([557d288](https://github.com/limitless-angular/limitless-angular/commit/557d2888e54618747ea8711d8cd0f25c7d5a3e9f))
+
+### ⚠️ Breaking Changes
+
+- add Angular 20 support (#56) ([4ebfeb5](https://github.com/limitless-angular/limitless-angular/commit/4ebfeb5af4a0184d29888f108005c610aba618a8))
+
+### ❤️ Thank You
+
+- Alfonso Andrés López Molina
+
 ## 19.2.0 (2025-02-22)
 
 ### 🚀 Features

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@limitless-angular/sanity",
-  "version": "19.2.0",
+  "version": "20.0.0-next.0",
   "description": "A powerful Angular library for Sanity.io integration, featuring Portable Text rendering and optimized image loading.",
   "scripts": {
     "build": "ng-packagr -c tsconfig.lib.prod.json",


### PR DESCRIPTION
## PR Checklist

Recovers from the partially completed release run https://github.com/limitless-angular/limitless-angular/actions/runs/27500780977.

The first attempt published `@limitless-angular/sanity@20.0.0-next.0` to npm with provenance, but the later `git push origin HEAD --follow-tags` was blocked by the protected `main` required status check. That left npm ahead of the repository.

## What is the new behavior?

This updates the repository release state to match the already-published npm package:

- bumps `packages/sanity/package.json` to `20.0.0-next.0`
- adds the generated `20.0.0-next.0` changelog section for the commits since `sanity@19.2.0`

After this PR merges, the remaining recovery work is to create `sanity@20.0.0-next.0` on the merged commit and create the matching GitHub Release. npm is already published and `next` already points at `20.0.0-next.0`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validated with:

- `pnpm exec prettier --check packages/sanity/package.json packages/sanity/CHANGELOG.md`
- `git diff --check`
- `pnpm --filter=@limitless-angular/release-tools run --silent release:plan --prerelease --json`
