### PR TITLE
fix(release): ignore package-irrelevant commits

### DIFF
--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -28,10 +28,10 @@ pnpm turbo run release:publish --filter=@limitless-angular/release-tools -- --ve
 pnpm turbo run release:publish --filter=@limitless-angular/release-tools -- --prerelease
 ```
 
-Prerelease mode infers the release level from conventional commits and uses the
-`next` prerelease identifier. For example, a feature-level release from
-`19.2.0` becomes `19.3.0-next.0`; the next prerelease in that train becomes
-`19.3.0-next.1`.
+Prerelease mode infers the release level from package-relevant conventional
+commits and uses the `next` prerelease identifier. For example, a feature-level
+release from `19.2.0` becomes `19.3.0-next.0`; the next prerelease in that train
+becomes `19.3.0-next.1`.
 
 ## Source of Truth
 
@@ -47,12 +47,40 @@ planned version only into the temporary compatibility build workspace and the
 packed npm tarball. Do not update the source package version or add a committed
 changelog for releases.
 
+## Package Relevance
+
+Release planning is package-aware. Each releasable package is configured in
+`tools/release/src/config.mjs` with:
+
+- `releasePaths`: repository paths that belong to the package.
+- `releaseScopes`: conventional commit scopes that explicitly target the
+  package.
+- `ignoredReleaseScopes`: infrastructure scopes that should not infer a package
+  release from the commit scope alone.
+- `ignoredReleaseScopePaths`: source-only metadata paths that ignored
+  infrastructure scopes may touch without inferring a package release.
+- `ignoredReleaseScopeJsonFields`: top-level JSON fields that ignored
+  infrastructure scopes may touch without inferring a package release.
+- `releaseTagPrefix`: the Git tag prefix for that package's versions.
+
+The planner derives inferred versions and GitHub Release notes from commits that
+either touch a configured package path or use a configured package scope. For
+`@limitless-angular/sanity`, a change under `packages/sanity/**` or a commit like
+`feat(sanity): add preview support` is release-relevant. Tooling-only commits
+such as `feat(release): harden publishing` do not create package releases, even
+when they touch configured source-only package metadata. For
+`packages/sanity/package.json`, only release-bookkeeping fields such as
+`version` and `private` are ignored this way; consumer-facing manifest changes
+such as dependency, peer dependency, or export updates still infer a release.
+Source changes still infer releases by path, even if their conventional commit
+scope is wrong. Maintainers can always pass an explicit `--version`.
+
 ## Pipeline
 
 Both dry-run and publish mode use the same release pipeline:
 
 1. Compute the release plan from the latest reachable `sanity@*` tag, explicit
-   version input, or conventional commits.
+   version input, or package-relevant conventional commits.
 2. In publish mode only, verify the release is running from `main`, the
    worktree matches `origin/main`, existing release state points at the current
    commit, npm trusted publishing OIDC is available, and `GITHUB_TOKEN` is

--- a/tools/release/src/config.mjs
+++ b/tools/release/src/config.mjs
@@ -13,3 +13,20 @@ export const initialReleaseVersion = '0.0.0';
 export const plannedPackageVersionEnv = 'LIMITLESS_RELEASE_VERSION';
 export const releaseTagPrefix = 'sanity@';
 export const repoUrl = 'https://github.com/limitless-angular/limitless-angular';
+
+export const releasePackages = [
+  {
+    name: '@limitless-angular/sanity',
+    ignoredReleaseScopes: ['release'],
+    ignoredReleaseScopeJsonFields: {
+      'packages/sanity/package.json': ['private', 'version'],
+    },
+    ignoredReleaseScopePaths: ['packages/sanity/CHANGELOG.md'],
+    packageJsonPath,
+    releasePaths: ['packages/sanity/**'],
+    releaseScopes: ['sanity'],
+    releaseTagPrefix,
+    root: 'packages/sanity',
+  },
+];
+export const defaultReleasePackage = releasePackages[0];

--- a/tools/release/src/pipeline.test.mjs
+++ b/tools/release/src/pipeline.test.mjs
@@ -293,6 +293,7 @@ function createReleaseFixture() {
 }
 
 function createReleaseHarness({
+  changedFiles = {},
   gitLog = '',
   githubRelease = null,
   headReleaseTags = [],
@@ -342,6 +343,10 @@ function createReleaseHarness({
 
       if (command === 'git' && args[0] === 'log') {
         return gitLog;
+      }
+
+      if (command === 'git' && args[0] === 'diff-tree') {
+        return (changedFiles[args.at(-1)] ?? []).join('\n');
       }
 
       if (command === 'git' && args[0] === 'ls-remote') {

--- a/tools/release/src/plan.mjs
+++ b/tools/release/src/plan.mjs
@@ -1,9 +1,10 @@
+import { isDeepStrictEqual } from 'node:util';
+
 import semver from 'semver';
 
 import {
+  defaultReleasePackage,
   initialReleaseVersion,
-  packageJsonPath,
-  releaseTagPrefix,
   repoUrl,
 } from './config.mjs';
 import { capture as defaultCapture } from './commands.mjs';
@@ -12,13 +13,17 @@ import { readJson } from './files.mjs';
 const prereleaseIdentifier = 'next';
 const prereleaseNpmDistTag = 'next';
 const stableNpmDistTag = 'latest';
+const missingJsonFile = Symbol('missingJsonFile');
+const invalidJsonFile = Symbol('invalidJsonFile');
 
 export function createReleasePlan(options = {}) {
-  const paths = resolveReleasePaths(options.paths);
+  const releasePackage = options.releasePackage ?? defaultReleasePackage;
+  const paths = resolveReleasePaths(options.paths, releasePackage);
   const commandCapture = options.capture ?? defaultCapture;
   const packageJson = readJson(paths.packageJsonPath);
   const packageRepositoryUrl = getRepositoryUrl(packageJson.repository);
-  const resolvedReleaseTagPrefix = options.releaseTagPrefix ?? releaseTagPrefix;
+  const resolvedReleaseTagPrefix =
+    options.releaseTagPrefix ?? releasePackage.releaseTagPrefix;
   const releaseTags = getReachableReleaseTags({
     capture: commandCapture,
     releaseTagPrefix: resolvedReleaseTagPrefix,
@@ -33,7 +38,8 @@ export function createReleasePlan(options = {}) {
     : latestReleaseTag;
   const currentVersion = releaseBaseTag?.version ?? initialReleaseVersion;
   const latestTag = releaseBaseTag?.tag ?? null;
-  const commits = getCommitsSince(latestTag, { capture: commandCapture });
+  const allCommits = getCommitsSince(latestTag, { capture: commandCapture });
+  const commits = filterReleaseCommits(allCommits, releasePackage);
   const requestedNextVersion = resolveNextVersion(currentVersion, commits, {
     prerelease: options.prerelease,
     versionSpecifier: options.versionSpecifier,
@@ -42,7 +48,7 @@ export function createReleasePlan(options = {}) {
 
   if (!nextVersion) {
     throw new Error(
-      'No release version could be determined. Pass --version or add a conventional commit with feat, fix, perf, refactor, or a breaking change.',
+      `No release version could be determined for ${releasePackage.name}. Pass --version or add a package-relevant conventional commit with feat, fix, perf, refactor, or a breaking change.`,
     );
   }
 
@@ -80,6 +86,7 @@ export function createReleasePlan(options = {}) {
     npmDistTag: isPrerelease ? prereleaseNpmDistTag : stableNpmDistTag,
     packageName: packageJson.name,
     packageRepositoryUrl,
+    releasePackage,
     paths,
     prerelease: isPrerelease,
     releaseNotes,
@@ -123,9 +130,9 @@ export function printReleasePlan(plan) {
   console.log(`Release commits: ${summary.commitCount}`);
 }
 
-function resolveReleasePaths(paths = {}) {
+function resolveReleasePaths(paths = {}, releasePackage) {
   return {
-    packageJsonPath: paths.packageJsonPath ?? packageJsonPath,
+    packageJsonPath: paths.packageJsonPath ?? releasePackage.packageJsonPath,
   };
 }
 
@@ -308,9 +315,219 @@ function getCommitsSince(tag, { capture }) {
     .map((entry) => {
       const [hash = '', subject = '', body = '', author = ''] =
         entry.split('\x01');
+      const changedJsonFields = new Map();
 
-      return { author, body, hash, subject };
+      return {
+        author,
+        body,
+        files: getCommitFiles(hash, { capture }),
+        getChangedJsonFields(file) {
+          const normalizedFile = normalizeRepoPath(file);
+
+          if (!changedJsonFields.has(normalizedFile)) {
+            changedJsonFields.set(
+              normalizedFile,
+              getChangedJsonFields(hash, normalizedFile, { capture }),
+            );
+          }
+
+          return changedJsonFields.get(normalizedFile);
+        },
+        hash,
+        subject,
+      };
     });
+}
+
+function getCommitFiles(hash, { capture }) {
+  const output = capture('git', [
+    'diff-tree',
+    '--no-commit-id',
+    '--name-only',
+    '-r',
+    '--root',
+    hash,
+  ]).trim();
+
+  if (!output) {
+    return [];
+  }
+
+  return output
+    .split('\n')
+    .map((file) => normalizeRepoPath(file))
+    .filter(Boolean);
+}
+
+function filterReleaseCommits(commits, releasePackage) {
+  return commits.filter((commit) => isReleaseCommit(commit, releasePackage));
+}
+
+function isReleaseCommit(commit, releasePackage) {
+  const releaseFiles = getReleaseFiles(commit, releasePackage);
+  const touchesPackagePath = releaseFiles.length > 0;
+
+  if (hasIgnoredReleaseScope(commit, releasePackage)) {
+    return releaseFiles.some(
+      (file) => !matchesIgnoredReleaseScopeFile(commit, file, releasePackage),
+    );
+  }
+
+  return hasReleaseScope(commit, releasePackage) || touchesPackagePath;
+}
+
+function hasReleaseScope(commit, releasePackage) {
+  const scope = getCommitScope(commit);
+  const releaseScopes = releasePackage.releaseScopes ?? [];
+
+  if (!scope || releaseScopes.length === 0) {
+    return false;
+  }
+
+  return releaseScopes.some(
+    (releaseScope) => releaseScope.toLowerCase() === scope.toLowerCase(),
+  );
+}
+
+function hasIgnoredReleaseScope(commit, releasePackage) {
+  const scope = getCommitScope(commit);
+  const ignoredScopes = releasePackage.ignoredReleaseScopes ?? [];
+
+  if (!scope || ignoredScopes.length === 0) {
+    return false;
+  }
+
+  return ignoredScopes.some(
+    (ignoredScope) => ignoredScope.toLowerCase() === scope.toLowerCase(),
+  );
+}
+
+function getReleaseFiles(commit, releasePackage) {
+  const releasePaths = releasePackage.releasePaths ?? [];
+
+  return commit.files.filter((file) =>
+    releasePaths.some((pattern) => matchesPathPattern(file, pattern)),
+  );
+}
+
+function matchesIgnoredReleaseScopeFile(commit, file, releasePackage) {
+  return (
+    matchesIgnoredReleaseScopePath(file, releasePackage) ||
+    matchesIgnoredReleaseScopeJsonFieldChange(commit, file, releasePackage)
+  );
+}
+
+function matchesIgnoredReleaseScopePath(file, releasePackage) {
+  const ignoredPaths = releasePackage.ignoredReleaseScopePaths ?? [];
+
+  return ignoredPaths.some((pattern) => matchesPathPattern(file, pattern));
+}
+
+function matchesIgnoredReleaseScopeJsonFieldChange(
+  commit,
+  file,
+  releasePackage,
+) {
+  const ignoredFields = getIgnoredReleaseScopeJsonFields(file, releasePackage);
+
+  if (ignoredFields.size === 0 || !commit.getChangedJsonFields) {
+    return false;
+  }
+
+  const changedFields = commit.getChangedJsonFields(file);
+
+  if (!changedFields) {
+    return false;
+  }
+
+  return changedFields.every((field) => ignoredFields.has(field));
+}
+
+function getIgnoredReleaseScopeJsonFields(file, releasePackage) {
+  const ignoredJsonFields = releasePackage.ignoredReleaseScopeJsonFields ?? {};
+  const fields = Object.entries(ignoredJsonFields).flatMap(
+    ([pattern, ignoredFields]) =>
+      matchesPathPattern(file, pattern) ? ignoredFields : [],
+  );
+
+  return new Set(fields);
+}
+
+function getChangedJsonFields(hash, file, { capture }) {
+  const before = readJsonAtCommit(`${hash}^`, file, { capture });
+  const after = readJsonAtCommit(hash, file, { capture });
+
+  if (
+    before === invalidJsonFile ||
+    after === invalidJsonFile ||
+    (before === missingJsonFile && after === missingJsonFile)
+  ) {
+    return null;
+  }
+
+  const beforeJson = before === missingJsonFile ? {} : before;
+  const afterJson = after === missingJsonFile ? {} : after;
+
+  return [...new Set([...Object.keys(beforeJson), ...Object.keys(afterJson)])]
+    .filter((field) => !isDeepStrictEqual(beforeJson[field], afterJson[field]))
+    .sort();
+}
+
+function readJsonAtCommit(revision, file, { capture }) {
+  try {
+    return JSON.parse(capture('git', ['show', `${revision}:${file}`]));
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return invalidJsonFile;
+    }
+
+    return missingJsonFile;
+  }
+}
+
+function matchesPathPattern(file, pattern) {
+  const normalizedFile = normalizeRepoPath(file);
+  const normalizedPattern = normalizeRepoPath(pattern);
+
+  if (normalizedPattern.endsWith('/**')) {
+    const directory = normalizedPattern.slice(0, -3);
+
+    return (
+      normalizedFile === directory || normalizedFile.startsWith(`${directory}/`)
+    );
+  }
+
+  if (normalizedPattern.includes('*')) {
+    return globPatternToRegExp(normalizedPattern).test(normalizedFile);
+  }
+
+  return (
+    normalizedFile === normalizedPattern ||
+    normalizedFile.startsWith(`${normalizedPattern}/`)
+  );
+}
+
+function globPatternToRegExp(pattern) {
+  const source = pattern
+    .split('/')
+    .map((segment) => {
+      if (segment === '**') {
+        return '.*';
+      }
+
+      return escapeRegExp(segment).replaceAll('\\*', '[^/]*');
+    })
+    .join('/');
+
+  return new RegExp(`^${source}$`);
+}
+
+function normalizeRepoPath(path) {
+  return path.replaceAll('\\', '/').replace(/^\.\//, '').trim();
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function buildReleaseNotes(version, commits, { now }) {
@@ -383,16 +600,33 @@ function formatAuthors(commits) {
 }
 
 function formatCommitSubject(subject) {
-  return subject.replace(/^\w+(?:\([^)]+\))?!?:\s*/, '');
+  return subject.replace(/^[a-zA-Z][\w-]*(?:\([^)]+\))?!?:\s*/, '');
 }
 
 function getCommitType(commit) {
-  return commit.subject.match(/^(\w+)(?:\([^)]+\))?!?:/)?.[1] ?? null;
+  return parseConventionalCommit(commit.subject)?.type ?? null;
+}
+
+function getCommitScope(commit) {
+  return parseConventionalCommit(commit.subject)?.scope ?? null;
+}
+
+function parseConventionalCommit(subject) {
+  const match = subject.match(/^([a-zA-Z][\w-]*)(?:\(([^)]+)\))?!?:/);
+
+  if (!match) {
+    return null;
+  }
+
+  return {
+    scope: match[2] ?? null,
+    type: match[1],
+  };
 }
 
 function isBreakingCommit(commit) {
   return (
-    /^\w+(?:\([^)]+\))!:/.test(commit.subject) ||
+    /^[a-zA-Z][\w-]*(?:\([^)]+\))!:/.test(commit.subject) ||
     /BREAKING CHANGE:/i.test(commit.body)
   );
 }

--- a/tools/release/src/plan.test.mjs
+++ b/tools/release/src/plan.test.mjs
@@ -85,6 +85,242 @@ test('release plan infers the next version from conventional commits', () => {
   }
 });
 
+test('release plan infers from package path changes without a package scope', () => {
+  const workspace = createReleaseFixture();
+
+  try {
+    const plan = createReleasePlan({
+      capture: createCapture({
+        changedFiles: {
+          abc1234: ['packages/sanity/src/index.ts'],
+        },
+        gitLog: 'abc1234\x01feat: add portable text support\x01\x01Alfonso\x02',
+      }),
+      now: new Date('2026-06-08T00:00:00.000Z'),
+      paths: workspace.paths,
+    });
+
+    assert.equal(plan.nextVersion, '1.1.0');
+    assert.equal(plan.commits.length, 1);
+    assert.match(plan.releaseNotes, /add portable text support/);
+  } finally {
+    workspace.cleanup();
+  }
+});
+
+test('release plan ignores tooling-only conventional commits', () => {
+  const workspace = createReleaseFixture();
+
+  try {
+    assert.throws(
+      () =>
+        createReleasePlan({
+          capture: createCapture({
+            changedFiles: {
+              abc1234: ['tools/release/src/plan.mjs'],
+            },
+            gitLog:
+              'abc1234\x01feat(release): publish from tags without source version churn\x01\x01Alfonso\x02',
+            releaseTags: ['sanity@20.0.0-next.0', 'sanity@19.2.0'],
+          }),
+          now: new Date('2026-06-08T00:00:00.000Z'),
+          paths: workspace.paths,
+          prerelease: true,
+        }),
+      /No release version could be determined for @limitless-angular\/sanity/,
+    );
+  } finally {
+    workspace.cleanup();
+  }
+});
+
+test('release plan ignores configured infrastructure scopes on source-only package metadata', () => {
+  const workspace = createReleaseFixture();
+
+  try {
+    assert.throws(
+      () =>
+        createReleasePlan({
+          capture: createCapture({
+            changedFiles: {
+              abc1234: [
+                'packages/sanity/CHANGELOG.md',
+                'packages/sanity/package.json',
+              ],
+            },
+            changedJsonFiles: {
+              abc1234: {
+                'packages/sanity/package.json': {
+                  after: createPackageManifest({
+                    private: true,
+                    version: '0.0.0-development',
+                  }),
+                  before: createPackageManifest({
+                    private: false,
+                    version: '19.2.0',
+                  }),
+                },
+              },
+            },
+            gitLog:
+              'abc1234\x01feat(release): publish from tags without source version churn\x01\x01Alfonso\x02',
+            releaseTags: ['sanity@20.0.0-next.0', 'sanity@19.2.0'],
+          }),
+          now: new Date('2026-06-08T00:00:00.000Z'),
+          paths: workspace.paths,
+          prerelease: true,
+        }),
+      /No release version could be determined for @limitless-angular\/sanity/,
+    );
+  } finally {
+    workspace.cleanup();
+  }
+});
+
+test('release plan includes infrastructure-scoped package manifest consumer changes', () => {
+  const workspace = createReleaseFixture();
+
+  try {
+    const plan = createReleasePlan({
+      capture: createCapture({
+        changedFiles: {
+          abc1234: ['packages/sanity/package.json'],
+        },
+        changedJsonFiles: {
+          abc1234: {
+            'packages/sanity/package.json': {
+              after: createPackageManifest({
+                peerDependencies: {
+                  '@angular/core': '^18.0.0 || ^19.0.0 || ^20.0.0',
+                },
+              }),
+              before: createPackageManifest({
+                peerDependencies: {
+                  '@angular/core': '^18.0.0 || ^19.0.0',
+                },
+              }),
+            },
+          },
+        },
+        gitLog:
+          'abc1234\x01fix(release): expand Angular peer dependency range\x01\x01Alfonso\x02',
+      }),
+      now: new Date('2026-06-08T00:00:00.000Z'),
+      paths: workspace.paths,
+    });
+
+    assert.equal(plan.nextVersion, '1.0.1');
+    assert.equal(plan.commits.length, 1);
+    assert.match(plan.releaseNotes, /expand Angular peer dependency range/);
+  } finally {
+    workspace.cleanup();
+  }
+});
+
+test('release plan includes configured infrastructure scopes on package source changes', () => {
+  const workspace = createReleaseFixture();
+
+  try {
+    const plan = createReleasePlan({
+      capture: createCapture({
+        changedFiles: {
+          abc1234: ['packages/sanity/src/index.ts'],
+        },
+        gitLog:
+          'abc1234\x01feat(release): add portable text support\x01\x01Alfonso\x02',
+      }),
+      now: new Date('2026-06-08T00:00:00.000Z'),
+      paths: workspace.paths,
+    });
+
+    assert.equal(plan.nextVersion, '1.1.0');
+    assert.equal(plan.commits.length, 1);
+    assert.match(plan.releaseNotes, /add portable text support/);
+  } finally {
+    workspace.cleanup();
+  }
+});
+
+test('release plan includes infrastructure-scoped commits with mixed metadata and source changes', () => {
+  const workspace = createReleaseFixture();
+
+  try {
+    const plan = createReleasePlan({
+      capture: createCapture({
+        changedFiles: {
+          abc1234: [
+            'packages/sanity/package.json',
+            'packages/sanity/src/index.ts',
+          ],
+        },
+        gitLog:
+          'abc1234\x01fix(release): handle live preview initialization\x01\x01Alfonso\x02',
+      }),
+      now: new Date('2026-06-08T00:00:00.000Z'),
+      paths: workspace.paths,
+    });
+
+    assert.equal(plan.nextVersion, '1.0.1');
+    assert.equal(plan.commits.length, 1);
+    assert.match(plan.releaseNotes, /handle live preview initialization/);
+  } finally {
+    workspace.cleanup();
+  }
+});
+
+test('release plan keeps notes scoped to package-relevant commits', () => {
+  const workspace = createReleaseFixture();
+
+  try {
+    const plan = createReleasePlan({
+      capture: createCapture({
+        changedFiles: {
+          abc1234: ['tools/release/src/plan.mjs'],
+          def5678: ['packages/sanity/src/index.ts'],
+        },
+        gitLog: [
+          'abc1234\x01feat(release): publish from tags without source version churn\x01\x01Alfonso',
+          'def5678\x01fix: handle live preview initialization\x01\x01Alfonso',
+        ].join('\x02'),
+      }),
+      now: new Date('2026-06-08T00:00:00.000Z'),
+      paths: workspace.paths,
+    });
+
+    assert.equal(plan.nextVersion, '1.0.1');
+    assert.equal(plan.commits.length, 1);
+    assert.match(plan.releaseNotes, /handle live preview initialization/);
+    assert.doesNotMatch(plan.releaseNotes, /publish from tags/);
+  } finally {
+    workspace.cleanup();
+  }
+});
+
+test('explicit release versions bypass package relevance inference', () => {
+  const workspace = createReleaseFixture();
+
+  try {
+    const plan = createReleasePlan({
+      capture: createCapture({
+        changedFiles: {
+          abc1234: ['tools/release/src/plan.mjs'],
+        },
+        gitLog:
+          'abc1234\x01feat(release): publish from tags without source version churn\x01\x01Alfonso\x02',
+      }),
+      now: new Date('2026-06-08T00:00:00.000Z'),
+      paths: workspace.paths,
+      versionSpecifier: '1.1.0',
+    });
+
+    assert.equal(plan.nextVersion, '1.1.0');
+    assert.equal(plan.commits.length, 0);
+    assert.doesNotMatch(plan.releaseNotes, /publish from tags/);
+  } finally {
+    workspace.cleanup();
+  }
+});
+
 test('prerelease plan infers next prerelease from conventional commits', () => {
   const workspace = createReleaseFixture();
 
@@ -188,7 +424,21 @@ function createReleaseFixture() {
   };
 }
 
+function createPackageManifest(overrides = {}) {
+  return {
+    name: '@limitless-angular/sanity',
+    peerDependencies: {
+      '@angular/core': '^18.0.0 || ^19.0.0',
+    },
+    private: false,
+    version: '19.2.0',
+    ...overrides,
+  };
+}
+
 function createCapture({
+  changedFiles = {},
+  changedJsonFiles = {},
   gitLog,
   headReleaseTags = [],
   releaseTags = ['sanity@1.0.0'],
@@ -206,6 +456,30 @@ function createCapture({
       return gitLog;
     }
 
+    if (command === 'git' && args[0] === 'diff-tree') {
+      return (changedFiles[args.at(-1)] ?? []).join('\n');
+    }
+
+    if (command === 'git' && args[0] === 'show') {
+      return captureGitShow(args[1], changedJsonFiles);
+    }
+
     throw new Error(`Unexpected command: ${command} ${args.join(' ')}`);
   };
+}
+
+function captureGitShow(ref, changedJsonFiles) {
+  const separatorIndex = ref.indexOf(':');
+  const revision = ref.slice(0, separatorIndex);
+  const file = ref.slice(separatorIndex + 1);
+  const before = revision.endsWith('^');
+  const hash = before ? revision.slice(0, -1) : revision;
+  const change = changedJsonFiles[hash]?.[file];
+  const json = before ? change?.before : change?.after;
+
+  if (json === undefined) {
+    throw new Error(`Missing git show fixture for ${ref}`);
+  }
+
+  return JSON.stringify(json);
 }


### PR DESCRIPTION
## PR Checklist

Release planning currently treats any conventional release-type commit after the latest `sanity@*` tag as a candidate package release. After the tag-driven release PR, that can make release-tooling commits look like `@limitless-angular/sanity` releases, especially when they touch source package metadata.

Closes #

N/A

## What is the new behavior?

- Adds config-driven package release metadata for `@limitless-angular/sanity`: release paths, release scopes, ignored infrastructure scopes, and tag prefix.
- Filters inferred release commits to package-relevant commits only.
- Keeps explicit `--version` releases as an override while keeping generated release notes package-focused.
- Ignores `feat(release): ...` style commits for package inference, including the real package-metadata case from the tag-driven release work.
- Documents package relevance rules for future packages.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validation run:

- `pnpm --filter=@limitless-angular/release-tools test`
- `pnpm --filter=@limitless-angular/release-tools run --silent release:plan --version 20.0.0 --json`
- `pnpm --filter=@limitless-angular/release-tools run --silent release:plan --prerelease` verified it now exits without planning a package release after the release-tooling PR.
- `pnpm exec prettier --check tools/release/README.md tools/release/src/config.mjs tools/release/src/pipeline.test.mjs tools/release/src/plan.mjs tools/release/src/plan.test.mjs`
- `git diff --check`

Post-Deploy Monitoring & Validation:

No additional operational monitoring required: this changes release planning logic only and does not affect runtime package code. Healthy signal is that future release dry-runs infer versions only from `packages/sanity/**` changes or `sanity`-scoped commits, while explicit `--version` releases still plan successfully.

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

N/A