### PR TITLE
fix(sanity): preserve Angular 18 template compatibility

### DIFF
--- a/packages/sanity/visual-editing/src/overlay-components/components/insert-menu.component.ts
+++ b/packages/sanity/visual-editing/src/overlay-components/components/insert-menu.component.ts
@@ -76,14 +76,15 @@ function getInsertMenuOptions(
               @if (previewImageUrl(schemaType); as previewImage) {
                 <img class="preview-image" [src]="previewImage" alt="" />
               } @else {
-                @let icon = iconFor(schemaType);
-                <span class="icon" [attr.aria-label]="icon.label">
-                  @if (icon.html) {
-                    <span [innerHTML]="icon.html"></span>
-                  } @else {
-                    {{ icon.text }}
-                  }
-                </span>
+                @if (iconFor(schemaType); as icon) {
+                  <span class="icon" [attr.aria-label]="icon.label">
+                    @if (icon.html) {
+                      <span [innerHTML]="icon.html"></span>
+                    } @else {
+                      {{ icon.text }}
+                    }
+                  </span>
+                }
               }
               <span class="label">{{ labelFor(schemaType) }}</span>
             </button>

--- a/packages/sanity/visual-editing/src/ui/context-menu/context-menu.component.ts
+++ b/packages/sanity/visual-editing/src/ui/context-menu/context-menu.component.ts
@@ -51,14 +51,15 @@ type ContextMenuState = NonNullable<OverlayState['contextMenu']>;
       #menu
     >
       <div class="header">
-        @let icon = titleIcon();
-        <span class="icon" [attr.aria-label]="icon.label">
-          @if (icon.html) {
-            <span [innerHTML]="icon.html"></span>
-          } @else {
-            {{ icon.text }}
-          }
-        </span>
+        @if (titleIcon(); as icon) {
+          <span class="icon" [attr.aria-label]="icon.label">
+            @if (icon.html) {
+              <span [innerHTML]="icon.html"></span>
+            } @else {
+              {{ icon.text }}
+            }
+          </span>
+        }
         <span class="title">{{ title() }}</span>
       </div>
       @if (items(); as items) {

--- a/tools/angular-compat/test-consumer.mjs
+++ b/tools/angular-compat/test-consumer.mjs
@@ -279,6 +279,12 @@ import {
   type PortableTextComponents,
   toPlainText,
 } from '@limitless-angular/sanity/portabletext';
+import {
+  VisualEditingComponent,
+  VisualEditingInsertMenuComponent,
+  type SchemaNode,
+  type SchemaUnionNode,
+} from '@limitless-angular/sanity/visual-editing';
 
 const blocks = [
   {
@@ -298,7 +304,12 @@ const sanityConfig = {
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [PortableTextComponent, SanityImage],
+  imports: [
+    PortableTextComponent,
+    SanityImage,
+    VisualEditingComponent,
+    VisualEditingInsertMenuComponent,
+  ],
   template: \`
     <p data-testid="compat-marker">{{ plainText }}</p>
     <article
@@ -316,12 +327,17 @@ const sanityConfig = {
       [sanityImage]="image"
       priority
     />
+    <ng-template>
+      <visual-editing />
+      <sanity-visual-editing-insert-menu [node]="insertMenuNode" />
+    </ng-template>
   \`,
 })
 class AppComponent {
   protected readonly blocks = blocks;
   protected readonly components: Partial<PortableTextComponents> = {};
   protected readonly image = 'image-abc123-120x80-png';
+  protected readonly insertMenuNode = {} as SchemaUnionNode<SchemaNode>;
   protected readonly plainText = toPlainText(blocks);
 }
 

--- a/tools/angular-compat/test-consumer.mjs
+++ b/tools/angular-compat/test-consumer.mjs
@@ -279,9 +279,15 @@ import {
   type PortableTextComponents,
   toPlainText,
 } from '@limitless-angular/sanity/portabletext';
+import { LiveQueryProviderComponent } from '@limitless-angular/sanity/preview-kit';
 import {
   VisualEditingComponent,
   VisualEditingInsertMenuComponent,
+  VisualEditingPointerEventsComponent,
+  VisualEditingUnionInsertMenuOverlayComponent,
+  type ElementNode,
+  type OverlayElementParent,
+  type SanityNode,
   type SchemaNode,
   type SchemaUnionNode,
 } from '@limitless-angular/sanity/visual-editing';
@@ -307,8 +313,11 @@ const sanityConfig = {
   imports: [
     PortableTextComponent,
     SanityImage,
+    LiveQueryProviderComponent,
     VisualEditingComponent,
     VisualEditingInsertMenuComponent,
+    VisualEditingPointerEventsComponent,
+    VisualEditingUnionInsertMenuOverlayComponent,
   ],
   template: \`
     <p data-testid="compat-marker">{{ plainText }}</p>
@@ -328,8 +337,15 @@ const sanityConfig = {
       priority
     />
     <ng-template>
+      <live-query-provider />
       <visual-editing />
       <sanity-visual-editing-insert-menu [node]="insertMenuNode" />
+      <sanity-visual-editing-pointer-events />
+      <sanity-visual-editing-union-insert-menu-overlay
+        [element]="overlayElement"
+        [node]="overlayNode"
+        [parent]="overlayParent"
+      />
     </ng-template>
   \`,
 })
@@ -338,6 +354,9 @@ class AppComponent {
   protected readonly components: Partial<PortableTextComponents> = {};
   protected readonly image = 'image-abc123-120x80-png';
   protected readonly insertMenuNode = {} as SchemaUnionNode<SchemaNode>;
+  protected readonly overlayElement = {} as ElementNode;
+  protected readonly overlayNode = {} as SanityNode;
+  protected readonly overlayParent = this.insertMenuNode as OverlayElementParent;
   protected readonly plainText = toPlainText(blocks);
 }
 


### PR DESCRIPTION
## PR Checklist

`@limitless-angular/sanity` declared Angular 18 support, but the published visual-editing entry point included `@let` syntax that Angular 18.0.x consumers cannot compile.

Closes #

N/A - no linked issue.

## What is the new behavior?

The visual editing insert menu and context menu templates now use `@if (...; as icon)` aliases instead of `@let`, preserving the rendered icon behavior while keeping the package compatible with the Angular 18 compiler floor promised by the peer dependency range.

The generated Angular compatibility consumer now covers the public Angular component surfaces more deliberately:

- Portable Text and Sanity image loading remain live runtime smoke checks with Playwright assertions.
- Preview kit and visual editing exported components are referenced from an inert `ng-template`, forcing Angular floor consumers to compile/link those component templates without changing runtime smoke behavior.
- The visual-editing lazy chunk is included in the Angular 18 floor build, so future template syntax regressions in that path should fail compatibility CI.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Testing:

- `rg -n "@let" packages/sanity`
- `pnpm --filter @limitless-angular/sanity build`
- `pnpm --filter @limitless-angular/sanity test`
- `pnpm run compat:pack`
- `pnpm run compat:test --set angular-18-floor --skip-runtime`
- `node --test tools/angular-compat/*.test.mjs`
- `pnpm run compat:test --set angular-18-floor`
- `git diff --check`

Negative verification:

- Temporarily reintroduced `@let icon = iconFor(schemaType)` in `VisualEditingInsertMenuComponent`, ran `pnpm run compat:pack`, then confirmed `pnpm run compat:test --set angular-18-floor --skip-runtime` failed under Angular 18.0.7 with `Incomplete block "let icon"`. The temporary source edit was reverted and the clean artifact was repacked before the final passing run.

Screenshots: N/A - no intended visual change.

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?