### PR TITLE
fix(release): retry npm publish verification

### DIFF
--- a/tools/release/src/publish.mjs
+++ b/tools/release/src/publish.mjs
@@ -11,6 +11,14 @@ import {
   npmRegistry,
   npmVersionExists,
 } from './state.mjs';
+import { retry } from './retry.mjs';
+
+const npmPublishVerificationRetry = {
+  attempts: 6,
+  delayMs: 5_000,
+  factor: 2,
+  maxDelayMs: 30_000,
+};
 
 export function ensureReleaseTag(plan, options = {}) {
   const commandCapture = options.capture ?? defaultCapture;
@@ -57,9 +65,14 @@ export function ensureReleaseTag(plan, options = {}) {
 export function publishTarball(plan, tarballPath, options = {}) {
   const commandCapture = options.capture ?? defaultCapture;
   const commandRun = options.run ?? defaultRun;
+  const retryOptions =
+    options.npmPublishVerificationRetry ?? npmPublishVerificationRetry;
 
   if (npmVersionExists(plan, { capture: commandCapture })) {
-    assertNpmDistTag(plan, { capture: commandCapture });
+    waitForNpmPublishedState(plan, {
+      capture: commandCapture,
+      retryOptions,
+    });
     console.log(
       `Skipping npm publish because ${plan.packageName}@${plan.nextVersion} already exists.`,
     );
@@ -81,14 +94,23 @@ export function publishTarball(plan, tarballPath, options = {}) {
 
   commandRun('npm', args);
 
-  if (!npmVersionExists(plan, { capture: commandCapture })) {
-    throw new Error(
-      `Published ${plan.packageName}@${plan.nextVersion}, but npm did not return that version.`,
-    );
-  }
-
-  assertNpmDistTag(plan, { capture: commandCapture });
+  waitForNpmPublishedState(plan, {
+    capture: commandCapture,
+    retryOptions,
+  });
   return true;
+}
+
+function waitForNpmPublishedState(plan, { capture, retryOptions }) {
+  retry(() => {
+    if (!npmVersionExists(plan, { capture })) {
+      throw new Error(
+        `Published ${plan.packageName}@${plan.nextVersion}, but npm did not return that version.`,
+      );
+    }
+
+    assertNpmDistTag(plan, { capture });
+  }, retryOptions);
 }
 
 export function createGitHubRelease(plan, options = {}) {

--- a/tools/release/src/publish.test.mjs
+++ b/tools/release/src/publish.test.mjs
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { publishTarball } from './publish.mjs';
+
+test('publish retries npm verification until the version and dist-tag are visible', () => {
+  const plan = createPlan();
+  const state = {
+    distTags: { latest: '1.0.0' },
+    published: false,
+    versionReads: 0,
+    versions: ['1.0.0'],
+  };
+  const commands = [];
+
+  const published = publishTarball(plan, '/tmp/release.tgz', {
+    capture(command, args) {
+      if (command === 'npm' && args[0] === 'view' && args[2] === 'versions') {
+        state.versionReads += 1;
+
+        if (state.published && state.versionReads >= 3) {
+          state.versions = ['1.0.0', '1.0.1'];
+        }
+
+        return JSON.stringify(state.versions);
+      }
+
+      if (command === 'npm' && args[0] === 'view' && args[2] === 'dist-tags') {
+        return JSON.stringify(state.distTags);
+      }
+
+      throw new Error(`Unexpected command: ${command} ${args.join(' ')}`);
+    },
+    npmPublishVerificationRetry: {
+      attempts: 3,
+      delayMs: 0,
+    },
+    run(command, args) {
+      commands.push([command, ...args].join(' '));
+
+      if (command === 'npm' && args[0] === 'publish') {
+        state.published = true;
+        state.distTags.latest = '1.0.1';
+      }
+    },
+  });
+
+  assert.equal(published, true);
+  assert.equal(state.versionReads, 3);
+  assert.deepEqual(commands, [
+    'npm publish /tmp/release.tgz --access public --registry https://registry.npmjs.org',
+  ]);
+});
+
+test('publish retries npm verification until the dist-tag points to the version', () => {
+  const plan = createPlan();
+  const state = {
+    distTagReads: 0,
+    distTags: { latest: '1.0.0' },
+    versions: ['1.0.0'],
+  };
+
+  publishTarball(plan, '/tmp/release.tgz', {
+    capture(command, args) {
+      if (command === 'npm' && args[0] === 'view' && args[2] === 'versions') {
+        return JSON.stringify(state.versions);
+      }
+
+      if (command === 'npm' && args[0] === 'view' && args[2] === 'dist-tags') {
+        state.distTagReads += 1;
+
+        if (state.distTagReads >= 2) {
+          state.distTags.latest = '1.0.1';
+        }
+
+        return JSON.stringify(state.distTags);
+      }
+
+      throw new Error(`Unexpected command: ${command} ${args.join(' ')}`);
+    },
+    npmPublishVerificationRetry: {
+      attempts: 2,
+      delayMs: 0,
+    },
+    run(command, args) {
+      if (command === 'npm' && args[0] === 'publish') {
+        state.versions.push('1.0.1');
+      }
+    },
+  });
+
+  assert.equal(state.distTagReads, 2);
+});
+
+function createPlan() {
+  return {
+    nextVersion: '1.0.1',
+    npmDistTag: 'latest',
+    packageName: '@limitless-angular/sanity',
+  };
+}

--- a/tools/release/src/retry.mjs
+++ b/tools/release/src/retry.mjs
@@ -1,0 +1,47 @@
+const defaultRetryOptions = {
+  attempts: 6,
+  delayMs: 5_000,
+  factor: 2,
+  maxDelayMs: 30_000,
+};
+
+export function retry(operation, options = {}) {
+  const attempts = options.attempts ?? defaultRetryOptions.attempts;
+  const factor = options.factor ?? defaultRetryOptions.factor;
+  const maxDelayMs = options.maxDelayMs ?? defaultRetryOptions.maxDelayMs;
+  const sleep = options.sleep ?? sleepSync;
+  let delayMs = options.delayMs ?? defaultRetryOptions.delayMs;
+  let lastError;
+
+  if (!Number.isInteger(attempts) || attempts < 1) {
+    throw new Error(
+      `Retry attempts must be a positive integer, got ${attempts}.`,
+    );
+  }
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return operation({ attempt, attempts });
+    } catch (error) {
+      lastError = error;
+
+      if (attempt === attempts) {
+        break;
+      }
+
+      sleep(delayMs);
+      delayMs = Math.min(delayMs * factor, maxDelayMs);
+    }
+  }
+
+  throw lastError;
+}
+
+function sleepSync(delayMs) {
+  if (delayMs <= 0) {
+    return;
+  }
+
+  // The release CLI is synchronous, so keep retry callers synchronous too.
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
+}


### PR DESCRIPTION
## Summary
- retry npm registry verification after publish so eventually consistent reads do not fail successful publishes
- verify both the published version and expected dist-tag before continuing
- cover stale npm version and dist-tag reads in release-tool tests

## Context
The publish workflow for sanity@20.0.0-next.1 succeeded on npm, but failed immediately afterward because npm view did not return the just-published version yet. Rerunning the job resumed correctly and created the GitHub Release, which confirmed the release state model works; this patch removes the avoidable transient failure.

## Verification
- pnpm --filter=@limitless-angular/release-tools test
- pnpm exec prettier --check tools/release/src/publish.mjs tools/release/src/retry.mjs tools/release/src/publish.test.mjs
- git diff --check