### PR TITLE
fix(sanity): align dependency ownership

### DIFF
--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -24,17 +24,18 @@ Limitless Angular is a powerful collection of Angular libraries focused on Sanit
 ## Installation
 
 ```bash
-npm install --save @limitless-angular/sanity
+npm install --save @limitless-angular/sanity @sanity/client
 ```
 
 ### Version Compatibility
 
-| Angular | `@limitless-angular/sanity` |
-| ------- | --------------------------- |
-| 19.x    | 19.x                        |
-| 18.x    | 19.x, 18.x                  |
+| Angular | Support |
+| ------- | ------- |
+| 20.x    | yes     |
+| 19.x    | yes     |
+| 18.x    | yes     |
 
-The current 19.x package line supports Angular 18 and Angular 19.
+The current package line supports Angular 18, Angular 19, and Angular 20.
 
 ## Quick Start
 

--- a/packages/sanity/image-loader/README.md
+++ b/packages/sanity/image-loader/README.md
@@ -13,7 +13,7 @@ The `@limitless-angular/sanity/image-loader` package provides two powerful featu
 1. Install the package:
 
 ```bash
-npm install --save @limitless-angular/sanity
+npm install --save @limitless-angular/sanity @sanity/client
 ```
 
 2. Configure in your `app.config.ts`:

--- a/packages/sanity/ng-package.json
+++ b/packages/sanity/ng-package.json
@@ -6,7 +6,10 @@
     "entryFile": "src/index.ts"
   },
   "allowedNonPeerDependencies": [
+    "@portabletext/toolkit",
+    "@portabletext/types",
     "@sanity/comlink",
+    "@sanity/image-url",
     "@sanity/mutate",
     "@sanity/presentation-comlink",
     "@sanity/visual-editing",

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -32,19 +32,19 @@
     "@angular/common": "^18.0.0 || ^19.0.0 || ^20.0.0",
     "@angular/core": "^18.0.0 || ^19.0.0 || ^20.0.0",
     "@angular/router": "^18.0.0 || ^19.0.0 || ^20.0.0",
-    "@portabletext/toolkit": "^2.0.15 || ^3.0.0 || ^4.0.0 || ^5.0.0",
-    "@portabletext/types": "^2.0.13 || ^3.0.0 || ^4.0.0",
     "@sanity/client": "^6.28.0 || ^7.0.0",
-    "@sanity/image-url": "^1.0.2 || ^2.0.2",
     "rxjs": "^7.8.0"
   },
   "peerDependenciesMeta": {
-    "@sanity/client": {
+    "@angular/router": {
       "optional": true
     }
   },
   "dependencies": {
+    "@portabletext/toolkit": "^2.0.15 || ^3.0.0 || ^4.0.0 || ^5.0.0",
+    "@portabletext/types": "^2.0.13 || ^3.0.0 || ^4.0.0",
     "@sanity/comlink": "^4.0.1",
+    "@sanity/image-url": "^1.0.2 || ^2.0.2",
     "@sanity/mutate": "0.18.0",
     "@sanity/presentation-comlink": "^2.1.0",
     "@sanity/visual-editing": "5.4.3",
@@ -65,10 +65,7 @@
     "@angular/core": "~20.0.0",
     "@angular/platform-browser": "~20.0.0",
     "@angular/router": "~20.0.0",
-    "@portabletext/toolkit": "^5.0.2",
-    "@portabletext/types": "^4.0.2",
     "@sanity/client": "^7.22.1",
-    "@sanity/image-url": "^2.1.1",
     "@testing-library/angular": "^18.1.1",
     "@testing-library/dom": "^10.4.0",
     "@types/lodash-es": "^4.17.12",

--- a/packages/sanity/portabletext/README.md
+++ b/packages/sanity/portabletext/README.md
@@ -33,7 +33,7 @@ You can also see the example project in the monorepo: [`apps/sanity-example`](/a
 ## Installation
 
 ```
-npm install --save @limitless-angular/sanity
+npm install --save @limitless-angular/sanity @sanity/client
 ```
 
 ## Basic usage

--- a/packages/sanity/preview-kit/README.md
+++ b/packages/sanity/preview-kit/README.md
@@ -24,10 +24,11 @@ The preview-kit provides real-time preview capabilities for Sanity content in An
 
 ## Installation
 
-The preview-kit is included with `@limitless-angular/sanity`. Install the main package:
+The preview-kit is included with `@limitless-angular/sanity`. Install the main
+package and its Sanity client peer:
 
 ```bash
-npm install @limitless-angular/sanity
+npm install @limitless-angular/sanity @sanity/client
 ```
 
 ## Basic Setup

--- a/packages/sanity/visual-editing/README.md
+++ b/packages/sanity/visual-editing/README.md
@@ -17,11 +17,16 @@ This secondary entry point is used to create clickable elements to take editors 
 
 ## Installation
 
-First, ensure you have installed the `@limitless-angular/sanity` package in your Angular project:
+First, ensure you have installed the `@limitless-angular/sanity` package and its
+Sanity client peer in your Angular project:
 
 ```bash
-npm install @limitless-angular/sanity
+npm install @limitless-angular/sanity @sanity/client
 ```
+
+Visual Editing uses Angular Router for client-side navigation. If your Angular
+app was created without routing, add `@angular/router` with the same major
+version as the rest of your Angular packages.
 
 ## Importing the Component
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,9 +440,18 @@ importers:
 
   packages/sanity:
     dependencies:
+      '@portabletext/toolkit':
+        specifier: ^2.0.15 || ^3.0.0 || ^4.0.0 || ^5.0.0
+        version: 5.0.2
+      '@portabletext/types':
+        specifier: ^2.0.13 || ^3.0.0 || ^4.0.0
+        version: 4.0.2
       '@sanity/comlink':
         specifier: ^4.0.1
         version: 4.0.1
+      '@sanity/image-url':
+        specifier: ^1.0.2 || ^2.0.2
+        version: 2.1.1
       '@sanity/mutate':
         specifier: 0.18.0
         version: 0.18.0(xstate@5.32.0)
@@ -498,18 +507,9 @@ importers:
       '@angular/router':
         specifier: ~20.0.0
         version: 20.0.7(@angular/common@20.0.7(@angular/core@20.0.7(@angular/compiler@20.0.7)(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@20.0.7(@angular/compiler@20.0.7)(rxjs@7.8.2)(zone.js@0.15.0))(@angular/platform-browser@20.0.7(@angular/animations@20.0.7(@angular/common@20.0.7(@angular/core@20.0.7(@angular/compiler@20.0.7)(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@20.0.7(@angular/compiler@20.0.7)(rxjs@7.8.2)(zone.js@0.15.0)))(@angular/common@20.0.7(@angular/core@20.0.7(@angular/compiler@20.0.7)(rxjs@7.8.2)(zone.js@0.15.0))(rxjs@7.8.2))(@angular/core@20.0.7(@angular/compiler@20.0.7)(rxjs@7.8.2)(zone.js@0.15.0)))(rxjs@7.8.2)
-      '@portabletext/toolkit':
-        specifier: ^5.0.2
-        version: 5.0.2
-      '@portabletext/types':
-        specifier: ^4.0.2
-        version: 4.0.2
       '@sanity/client':
         specifier: ^7.22.1
         version: 7.22.1
-      '@sanity/image-url':
-        specifier: ^2.1.1
-        version: 2.1.1
       '@testing-library/angular':
         specifier: ^18.1.1
         version: 18.1.1(a6dfd35be83c1214ec6d4ab10dc81735)

--- a/tools/angular-compat/package-manifest-policy.test.mjs
+++ b/tools/angular-compat/package-manifest-policy.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { readJson } from './lib.mjs';
+
+const sanityPackageJson = readJson(
+  new URL('../../packages/sanity/package.json', import.meta.url),
+);
+const sanityNgPackageJson = readJson(
+  new URL('../../packages/sanity/ng-package.json', import.meta.url),
+);
+
+const peerOwnedDependencies = [
+  '@angular/common',
+  '@angular/core',
+  '@angular/router',
+  '@sanity/client',
+  'rxjs',
+];
+const bundledFeatureDependencies = [
+  '@portabletext/toolkit',
+  '@portabletext/types',
+  '@sanity/image-url',
+];
+
+test('@limitless-angular/sanity keeps framework and client packages peer-owned', () => {
+  const dependencies = dependencyNames('dependencies');
+  const peerDependencies = dependencyNames('peerDependencies');
+
+  for (const dependency of peerOwnedDependencies) {
+    assert.ok(
+      peerDependencies.has(dependency),
+      `${dependency} should be a peer dependency`,
+    );
+    assert.ok(
+      !dependencies.has(dependency),
+      `${dependency} should not be bundled as a runtime dependency`,
+    );
+  }
+
+  assert.deepEqual(sanityPackageJson.peerDependenciesMeta ?? {}, {
+    '@angular/router': { optional: true },
+  });
+});
+
+test('@limitless-angular/sanity bundles feature implementation helpers', () => {
+  const dependencies = dependencyNames('dependencies');
+  const peerDependencies = dependencyNames('peerDependencies');
+  const devDependencies = dependencyNames('devDependencies');
+  const allowedNonPeerDependencies = new Set(
+    sanityNgPackageJson.allowedNonPeerDependencies ?? [],
+  );
+
+  for (const dependency of bundledFeatureDependencies) {
+    assert.ok(
+      dependencies.has(dependency),
+      `${dependency} should be a runtime dependency`,
+    );
+    assert.ok(
+      !peerDependencies.has(dependency),
+      `${dependency} should not be a peer dependency`,
+    );
+    assert.ok(
+      !devDependencies.has(dependency),
+      `${dependency} should not be duplicated in devDependencies`,
+    );
+    assert.ok(
+      allowedNonPeerDependencies.has(dependency),
+      `${dependency} should be allowed by ng-packagr as a non-peer dependency`,
+    );
+  }
+});
+
+test('@limitless-angular/sanity avoids dependency bucket duplication', () => {
+  const dependencies = dependencyNames('dependencies');
+  const peerDependencies = dependencyNames('peerDependencies');
+  const devDependencies = dependencyNames('devDependencies');
+
+  for (const dependency of dependencies) {
+    assert.ok(
+      !devDependencies.has(dependency),
+      `${dependency} should not be duplicated in devDependencies`,
+    );
+  }
+
+  for (const dependency of peerDependencies) {
+    assert.ok(
+      !dependencies.has(dependency),
+      `${dependency} should not be both a dependency and peerDependency`,
+    );
+  }
+});
+
+function dependencyNames(section) {
+  return new Set(Object.keys(sanityPackageJson[section] ?? {}));
+}

--- a/tools/angular-compat/test-consumer.mjs
+++ b/tools/angular-compat/test-consumer.mjs
@@ -94,11 +94,22 @@ function writeConsumerProject(
   const packageName = `sanity-${versionSet.id}-compat-consumer`;
   const runtimePort = getRuntimePort(versionSet.id);
   const sharedSanityDeps = {
-    '@portabletext/toolkit':
-      packageJson.peerDependencies['@portabletext/toolkit'],
-    '@portabletext/types': packageJson.peerDependencies['@portabletext/types'],
-    '@sanity/client': packageJson.peerDependencies['@sanity/client'],
-    '@sanity/image-url': packageJson.peerDependencies['@sanity/image-url'],
+    '@portabletext/toolkit': getPublishedDependencyRange(
+      packageJson,
+      '@portabletext/toolkit',
+    ),
+    '@portabletext/types': getPublishedDependencyRange(
+      packageJson,
+      '@portabletext/types',
+    ),
+    '@sanity/client': getPublishedDependencyRange(
+      packageJson,
+      '@sanity/client',
+    ),
+    '@sanity/image-url': getPublishedDependencyRange(
+      packageJson,
+      '@sanity/image-url',
+    ),
     rxjs: packageJson.peerDependencies.rxjs,
     tslib: packageJson.dependencies.tslib,
   };
@@ -243,6 +254,20 @@ function writeConsumerProject(
   );
 
   console.log(`Consumer workspace: ${relative(workspaceRoot, workspace)}`);
+}
+
+function getPublishedDependencyRange(packageJson, dependencyName) {
+  const range =
+    packageJson.dependencies?.[dependencyName] ??
+    packageJson.peerDependencies?.[dependencyName];
+
+  if (!range) {
+    throw new Error(
+      `Expected ${dependencyName} in dependencies or peerDependencies.`,
+    );
+  }
+
+  return range;
 }
 
 function entrypointsSource() {


### PR DESCRIPTION
## PR Checklist

Clarifies and enforces how the published `@limitless-angular/sanity` package owns peer dependencies versus bundled runtime dependencies.

Closes N/A

## What is the new behavior?

- Keeps Angular framework packages, RxJS, and `@sanity/client` as peer-owned integration dependencies.
- Marks `@angular/router` as an optional peer because it is only needed by Visual Editing.
- Moves Portable Text helper packages and `@sanity/image-url` to runtime dependencies and allows them in `ng-package.json`.
- Updates package README install snippets to include the required Sanity client peer and the current Angular 18/19/20 support table.
- Adds a manifest-policy test so future changes do not accidentally drift dependency ownership.
- Keeps compatibility consumers resilient by reading dependency ranges from either `dependencies` or `peerDependencies`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validation:

- `pnpm --filter @limitless-angular/sanity build`
- `pnpm --filter @limitless-angular/sanity lint`
- `pnpm --filter @limitless-angular/sanity test`
- `pnpm --filter @limitless-angular/angular-compat test`
- `pnpm compat:assert`
- `pnpm compat:pack`
- `pnpm compat:artifact`
- `pnpm compat:test`
- `git diff --check`

Notes:

- `compat:test` passed generated Angular 18, 19, and 20 consumers against the packed tarball.
- `@sanity/client@6.28.0` exposes the `./csm` and `./stega` subpaths this package imports, but installing with v6 still produces peer warnings from transitive Sanity Visual Editing packages that prefer v7. That range is preserved here to avoid a breaking change.
- `pnpm peers check` still reports pre-existing workspace/tooling peer warnings unrelated to this PR.

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

N/A
