### PR TITLE
fix(release): aggregate stable release notes

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -141,6 +141,8 @@ jobs:
               `- Release tag: ${plan.releaseTag}`,
               `- npm dist-tag: ${plan.npmDistTag}`,
               `- Commit count: ${plan.commitCount}`,
+              `- Release notes base tag: ${plan.releaseNotesBaseTag || 'none'}`,
+              `- Release note commit count: ${plan.releaseNotesCommitCount}`,
             );
           } else {
             lines.push('- Planned version: unavailable; release planning did not complete.');

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -124,6 +124,8 @@ jobs:
               `- Release tag: ${plan.releaseTag}`,
               `- npm dist-tag: ${plan.npmDistTag}`,
               `- Commit count: ${plan.commitCount}`,
+              `- Release notes base tag: ${plan.releaseNotesBaseTag || 'none'}`,
+              `- Release note commit count: ${plan.releaseNotesCommitCount}`,
             );
           } else {
             lines.push('- Planned version: unavailable; release planning did not complete.');

--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -63,24 +63,32 @@ Release planning is package-aware. Each releasable package is configured in
   infrastructure scopes may touch without inferring a package release.
 - `releaseTagPrefix`: the Git tag prefix for that package's versions.
 
-The planner derives inferred versions and GitHub Release notes from commits that
-either touch a configured package path or use a configured package scope. For
-`@limitless-angular/sanity`, a change under `packages/sanity/**` or a commit like
-`feat(sanity): add preview support` is release-relevant. Tooling-only commits
-such as `feat(release): harden publishing` do not create package releases, even
-when they touch configured source-only package metadata. For
+The planner derives inferred versions from commits that either touch a
+configured package path or use a configured package scope. For
+`@limitless-angular/sanity`, a change under `packages/sanity/**` or a commit
+like `feat(sanity): add preview support` is release-relevant. Tooling-only
+commits such as `feat(release): harden publishing` do not create package
+releases, even when they touch configured source-only package metadata. For
 `packages/sanity/package.json`, only release-bookkeeping fields such as
 `version` and `private` are ignored this way; consumer-facing manifest changes
 such as dependency, peer dependency, or export updates still infer a release.
 Source changes still infer releases by path, even if their conventional commit
 scope is wrong. Maintainers can always pass an explicit `--version`.
 
+GitHub Release notes use the same package-relevance filter, but their base tag
+depends on the release type. Prerelease notes are incremental from the latest
+reachable `sanity@*` tag. Stable release notes start at the latest stable
+`sanity@*` tag, ignoring prerelease tags, so a final `20.0.0` release summarizes
+the full `20.0.0-next.*` train since the previous stable release.
+
 ## Pipeline
 
 Both dry-run and publish mode use the same release pipeline:
 
 1. Compute the release plan from the latest reachable `sanity@*` tag, explicit
-   version input, or package-relevant conventional commits.
+   version input, or package-relevant conventional commits. Stable GitHub
+   Release notes use the latest stable tag as their base so final releases
+   summarize their prerelease train.
 2. In publish mode only, verify the release is running from `main`, the
    worktree matches `origin/main`, existing release state points at the current
    commit, npm trusted publishing OIDC is available, and `GITHUB_TOKEN` is

--- a/tools/release/src/plan.mjs
+++ b/tools/release/src/plan.mjs
@@ -72,7 +72,20 @@ export function createReleasePlan(options = {}) {
   const releaseTag =
     headReleaseTag?.tag ?? `${resolvedReleaseTagPrefix}${nextVersion}`;
   const isPrerelease = Boolean(semver.prerelease(nextVersion));
-  const releaseNotes = buildReleaseNotes(nextVersion, commits, {
+  const releaseNotesBaseTag = resolveReleaseNotesBaseTag({
+    headReleaseTag,
+    prerelease: isPrerelease,
+    releaseBaseTag,
+    releaseTags,
+  });
+  const releaseNotesCommits =
+    releaseNotesBaseTag === latestTag
+      ? commits
+      : filterReleaseCommits(
+          getCommitsSince(releaseNotesBaseTag, { capture: commandCapture }),
+          releasePackage,
+        );
+  const releaseNotes = buildReleaseNotes(nextVersion, releaseNotesCommits, {
     now: generatedAt,
   });
 
@@ -90,6 +103,8 @@ export function createReleasePlan(options = {}) {
     paths,
     prerelease: isPrerelease,
     releaseNotes,
+    releaseNotesBaseTag,
+    releaseNotesCommits,
     releaseTag,
     sourceVersion: packageJson.version,
   };
@@ -114,6 +129,8 @@ export function summarizeReleasePlan(plan) {
     npmDistTag: plan.npmDistTag,
     packageName: plan.packageName,
     prerelease: plan.prerelease,
+    releaseNotesBaseTag: plan.releaseNotesBaseTag,
+    releaseNotesCommitCount: plan.releaseNotesCommits.length,
     releaseTag: plan.releaseTag,
   };
 }
@@ -128,6 +145,10 @@ export function printReleasePlan(plan) {
   console.log(`npm dist-tag: ${summary.npmDistTag}`);
   console.log(`Release tag: ${summary.releaseTag}`);
   console.log(`Release commits: ${summary.commitCount}`);
+  console.log(
+    `Release notes base tag: ${summary.releaseNotesBaseTag ?? 'none'}`,
+  );
+  console.log(`Release note commits: ${summary.releaseNotesCommitCount}`);
 }
 
 function resolveReleasePaths(paths = {}, releasePackage) {
@@ -246,6 +267,29 @@ function toPrereleaseIncrement(specifier) {
     default:
       return null;
   }
+}
+
+function resolveReleaseNotesBaseTag({
+  headReleaseTag,
+  prerelease,
+  releaseBaseTag,
+  releaseTags,
+}) {
+  if (prerelease) {
+    return releaseBaseTag?.tag ?? null;
+  }
+
+  return (
+    getLatestStableReleaseTag(releaseTags, {
+      excludeTag: headReleaseTag?.tag,
+    })?.tag ?? null
+  );
+}
+
+function getLatestStableReleaseTag(releaseTags, { excludeTag } = {}) {
+  return releaseTags.find(
+    (tag) => tag.tag !== excludeTag && !semver.prerelease(tag.version),
+  );
 }
 
 function getReachableReleaseTags({ capture, releaseTagPrefix }) {

--- a/tools/release/src/plan.test.mjs
+++ b/tools/release/src/plan.test.mjs
@@ -4,7 +4,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 
-import { createReleasePlan, resolveReleaseSpecifier } from './plan.mjs';
+import {
+  createReleasePlan,
+  resolveReleaseSpecifier,
+  summarizeReleasePlan,
+} from './plan.mjs';
 
 test('release specifier accepts semver increments and explicit versions', () => {
   assert.equal(resolveReleaseSpecifier('1.2.3', 'patch'), '1.2.4');
@@ -364,7 +368,82 @@ test('prerelease plan increments the current prerelease train', () => {
     assert.equal(plan.currentVersion, '1.1.0-next.0');
     assert.equal(plan.nextVersion, '1.1.0-next.1');
     assert.equal(plan.npmDistTag, 'next');
+    assert.equal(plan.releaseNotesBaseTag, 'sanity@1.1.0-next.0');
+    assert.equal(plan.releaseNotesCommits.length, 1);
     assert.equal(plan.releaseTag, 'sanity@1.1.0-next.1');
+  } finally {
+    workspace.cleanup();
+  }
+});
+
+test('stable release notes include the full prerelease train', () => {
+  const workspace = createReleaseFixture();
+
+  try {
+    const plan = createReleasePlan({
+      capture: createCapture({
+        gitLogs: {
+          'sanity@1.1.0-next.1..HEAD': '',
+          'sanity@1.0.0..HEAD': [
+            'abc1234\x01feat(sanity): add portable text support\x01\x01Alfonso',
+            'def5678\x01fix(sanity): handle live preview initialization\x01\x01Blanca',
+            'fed9876\x01feat(release): publish from tags without source version churn\x01\x01Alfonso',
+          ].join('\x02'),
+        },
+        releaseTags: [
+          'sanity@1.1.0-next.1',
+          'sanity@1.1.0-next.0',
+          'sanity@1.0.0',
+        ],
+      }),
+      now: new Date('2026-06-08T00:00:00.000Z'),
+      paths: workspace.paths,
+      versionSpecifier: '1.1.0',
+    });
+
+    assert.equal(plan.currentVersion, '1.1.0-next.1');
+    assert.equal(plan.nextVersion, '1.1.0');
+    assert.equal(plan.latestTag, 'sanity@1.1.0-next.1');
+    assert.equal(plan.commits.length, 0);
+    assert.equal(plan.releaseNotesBaseTag, 'sanity@1.0.0');
+    assert.equal(plan.releaseNotesCommits.length, 2);
+    assert.match(plan.releaseNotes, /add portable text support/);
+    assert.match(plan.releaseNotes, /handle live preview initialization/);
+    assert.doesNotMatch(plan.releaseNotes, /publish from tags/);
+
+    const summary = summarizeReleasePlan(plan);
+
+    assert.equal(summary.releaseNotesBaseTag, 'sanity@1.0.0');
+    assert.equal(summary.releaseNotesCommitCount, 2);
+  } finally {
+    workspace.cleanup();
+  }
+});
+
+test('stable release resume keeps notes based on the previous stable tag', () => {
+  const workspace = createReleaseFixture();
+
+  try {
+    const plan = createReleasePlan({
+      capture: createCapture({
+        gitLogs: {
+          'sanity@1.1.0-next.1..HEAD': '',
+          'sanity@1.0.0..HEAD':
+            'abc1234\x01feat(sanity): add portable text support\x01\x01Alfonso\x02',
+        },
+        headReleaseTags: ['sanity@1.1.0'],
+        releaseTags: ['sanity@1.1.0', 'sanity@1.1.0-next.1', 'sanity@1.0.0'],
+      }),
+      now: new Date('2026-06-08T00:00:00.000Z'),
+      paths: workspace.paths,
+    });
+
+    assert.equal(plan.existingReleaseTag, true);
+    assert.equal(plan.currentVersion, '1.1.0-next.1');
+    assert.equal(plan.nextVersion, '1.1.0');
+    assert.equal(plan.releaseNotesBaseTag, 'sanity@1.0.0');
+    assert.equal(plan.releaseNotesCommits.length, 1);
+    assert.match(plan.releaseNotes, /add portable text support/);
   } finally {
     workspace.cleanup();
   }
@@ -440,6 +519,7 @@ function createCapture({
   changedFiles = {},
   changedJsonFiles = {},
   gitLog,
+  gitLogs = {},
   headReleaseTags = [],
   releaseTags = ['sanity@1.0.0'],
 }) {
@@ -453,7 +533,7 @@ function createCapture({
     }
 
     if (command === 'git' && args[0] === 'log') {
-      return gitLog;
+      return gitLogs[args[1]] ?? gitLog;
     }
 
     if (command === 'git' && args[0] === 'diff-tree') {


### PR DESCRIPTION
## Summary
- split release planning's version base from the GitHub Release notes base
- keep prerelease notes incremental from the latest reachable release tag
- aggregate stable release notes from the latest stable tag, ignoring prerelease tags
- expose release notes base and note commit count in plan JSON and workflow summaries
- document the stable/prerelease release notes model

## v20 plan smoke test
```json
{
  "currentVersion": "20.0.0-next.2",
  "latestTag": "sanity@20.0.0-next.2",
  "nextVersion": "20.0.0",
  "releaseNotesBaseTag": "sanity@19.2.0",
  "releaseNotesCommitCount": 24,
  "releaseTag": "sanity@20.0.0"
}
```

## Verification
- pnpm --filter=@limitless-angular/release-tools test
- pnpm exec prettier --check tools/release/src/plan.mjs tools/release/src/plan.test.mjs tools/release/README.md .github/workflows/release-dry-run.yml .github/workflows/release-and-publish.yml
- git diff --check
- pnpm --filter=@limitless-angular/release-tools run --silent release:plan --version 20.0.0 --json