### PR TITLE
docs(sanity): restore Angular compatibility table

### DIFF
--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -29,13 +29,13 @@ npm install --save @limitless-angular/sanity @sanity/client
 
 ### Version Compatibility
 
-| Angular | Support |
-| ------- | ------- |
-| 20.x    | yes     |
-| 19.x    | yes     |
-| 18.x    | yes     |
+| Angular | `@limitless-angular/sanity` |
+| ------- | --------------------------- |
+| 20.x    | 20.x                        |
+| 19.x    | 20.x, 19.x                  |
+| 18.x    | 20.x, 19.x, 18.x            |
 
-The current package line supports Angular 18, Angular 19, and Angular 20.
+The current 20.x package line supports Angular 18, Angular 19, and Angular 20.
 
 ## Quick Start
 


### PR DESCRIPTION
## PR Checklist

Restores the public compatibility table format that maps Angular majors to compatible `@limitless-angular/sanity` package lines.

Closes #

N/A

## What is the new behavior?

The Version Compatibility table once again uses the package-line matrix format, now updated for Angular 20 support:

- Angular 20 maps to the 20.x package line.
- Angular 19 maps to 20.x and 19.x package lines.
- Angular 18 maps to 20.x, 19.x, and 18.x package lines.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validation:

- `pnpm run compat:assert`
- `pnpm run compat:matrix`

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

N/A
