### PR TITLE
fix(release): include breaking change details in notes

### DIFF
--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -79,7 +79,9 @@ GitHub Release notes use the same package-relevance filter, but their base tag
 depends on the release type. Prerelease notes are incremental from the latest
 reachable `sanity@*` tag. Stable release notes start at the latest stable
 `sanity@*` tag, ignoring prerelease tags, so a final `20.0.0` release summarizes
-the full `20.0.0-next.*` train since the previous stable release.
+the full `20.0.0-next.*` train since the previous stable release. Breaking
+change sections include the `BREAKING CHANGE:` footer text when commits provide
+one.
 
 ## Pipeline
 

--- a/tools/release/src/plan.mjs
+++ b/tools/release/src/plan.mjs
@@ -603,7 +603,10 @@ function buildReleaseNotes(version, commits, { now }) {
     formatCommitGroup('### 🚀 Features', groupedCommits.features),
     formatCommitGroup('### 🩹 Fixes', groupedCommits.fixes),
     formatCommitGroup('### 🧹 Refactors', groupedCommits.refactors),
-    formatCommitGroup('### ⚠️ Breaking Changes', groupedCommits.breaking),
+    formatBreakingCommitGroup(
+      '### ⚠️ Breaking Changes',
+      groupedCommits.breaking,
+    ),
     formatAuthors(commits),
   ].filter(Boolean);
 
@@ -620,11 +623,29 @@ function formatCommitGroup(title, commits) {
   return [
     title,
     '',
-    ...commits.map(
-      (commit) =>
-        `- ${formatCommitSubject(commit.subject)} ([${commit.hash.slice(0, 7)}](${repoUrl}/commit/${commit.hash}))`,
-    ),
+    ...commits.map((commit) => formatCommitBullet(commit)),
   ].join('\n');
+}
+
+function formatBreakingCommitGroup(title, commits) {
+  if (commits.length === 0) {
+    return null;
+  }
+
+  return [
+    title,
+    '',
+    ...commits.flatMap((commit) => [
+      formatCommitBullet(commit),
+      ...getBreakingChangeDescriptions(commit.body).map(
+        (description) => `  - ${description}`,
+      ),
+    ]),
+  ].join('\n');
+}
+
+function formatCommitBullet(commit) {
+  return `- ${formatCommitSubject(commit.subject)} ([${commit.hash.slice(0, 7)}](${repoUrl}/commit/${commit.hash}))`;
 }
 
 function formatAuthors(commits) {
@@ -668,9 +689,65 @@ function parseConventionalCommit(subject) {
   };
 }
 
+function getBreakingChangeDescriptions(body) {
+  const descriptions = [];
+  const lines = (body ?? '').replace(/\r\n?/g, '\n').split('\n');
+  let currentDescription = null;
+
+  for (const line of lines) {
+    const breakingChangeMatch = line.match(/^BREAKING(?: |-)CHANGE:\s*(.*)$/i);
+
+    if (breakingChangeMatch) {
+      pushBreakingChangeDescription(descriptions, currentDescription);
+      currentDescription = [breakingChangeMatch[1]];
+      continue;
+    }
+
+    if (!currentDescription) {
+      continue;
+    }
+
+    if (line.trim() === '') {
+      pushBreakingChangeDescription(descriptions, currentDescription);
+      currentDescription = null;
+      continue;
+    }
+
+    if (isConventionalFooterLine(line)) {
+      pushBreakingChangeDescription(descriptions, currentDescription);
+      currentDescription = null;
+      continue;
+    }
+
+    currentDescription.push(line);
+  }
+
+  pushBreakingChangeDescription(descriptions, currentDescription);
+
+  return descriptions;
+}
+
+function pushBreakingChangeDescription(descriptions, lines) {
+  const description = lines
+    ?.join('\n')
+    .trim()
+    .replace(/[ \t]*\n[ \t]*/g, ' ')
+    .replace(/[ \t]+/g, ' ');
+
+  if (description) {
+    descriptions.push(description);
+  }
+}
+
+function isConventionalFooterLine(line) {
+  return /^[A-Za-z][A-Za-z0-9-]*(?: [A-Za-z][A-Za-z0-9-]*)?:\s+/.test(
+    line.trim(),
+  );
+}
+
 function isBreakingCommit(commit) {
   return (
     /^[a-zA-Z][\w-]*(?:\([^)]+\))!:/.test(commit.subject) ||
-    /BREAKING CHANGE:/i.test(commit.body)
+    getBreakingChangeDescriptions(commit.body).length > 0
   );
 }

--- a/tools/release/src/plan.test.mjs
+++ b/tools/release/src/plan.test.mjs
@@ -300,6 +300,43 @@ test('release plan keeps notes scoped to package-relevant commits', () => {
   }
 });
 
+test('release notes include breaking change descriptions', () => {
+  const workspace = createReleaseFixture();
+
+  try {
+    const plan = createReleasePlan({
+      capture: createCapture({
+        gitLog: [
+          'abc1234',
+          'feat(sanity): add Angular 20 support',
+          [
+            'BREAKING CHANGE: Angular 17 is no longer supported.',
+            'Consumers must use Angular 18 or newer.',
+            '',
+            '* [autofix.ci] apply automated fixes',
+            'Refs: #123',
+          ].join('\n'),
+          'Alfonso',
+        ].join('\x01'),
+      }),
+      now: new Date('2026-06-08T00:00:00.000Z'),
+      paths: workspace.paths,
+    });
+
+    assert.equal(plan.nextVersion, '2.0.0');
+    assert.match(plan.releaseNotes, /### ⚠️ Breaking Changes/);
+    assert.match(plan.releaseNotes, /- add Angular 20 support/);
+    assert.match(
+      plan.releaseNotes,
+      /  - Angular 17 is no longer supported\. Consumers must use Angular 18 or newer\./,
+    );
+    assert.doesNotMatch(plan.releaseNotes, /autofix/);
+    assert.doesNotMatch(plan.releaseNotes, /Refs: #123/);
+  } finally {
+    workspace.cleanup();
+  }
+});
+
 test('explicit release versions bypass package relevance inference', () => {
   const workspace = createReleaseFixture();
 


### PR DESCRIPTION
## Summary
- include `BREAKING CHANGE:` footer text under breaking-change release note bullets
- reuse the same footer extraction for breaking-change detection and note rendering
- stop extraction before unrelated footers or PR metadata so generated notes stay clean
- document that breaking sections include footer text when provided

## v20 notes preview
```md
### ⚠️ Breaking Changes

- add Angular 20 support (#56) ([4ebfeb5](https://github.com/limitless-angular/limitless-angular/commit/4ebfeb5af4a0184d29888f108005c610aba618a8))
  - mark the Angular 20 compatibility update as a breaking release for package consumers.
```

## Verification
- pnpm --filter=@limitless-angular/release-tools test
- pnpm exec prettier --check tools/release/src/plan.mjs tools/release/src/plan.test.mjs tools/release/README.md
- git diff --check
- node --input-type=module -e "import { createReleasePlan } from './tools/release/src/plan.mjs'; const plan = createReleasePlan({ versionSpecifier: '20.0.0' }); console.log(plan.releaseNotes);"