### PR TITLE
chore(sanity): replace deprecated APIs

### DIFF
--- a/packages/sanity/src/providers.ts
+++ b/packages/sanity/src/providers.ts
@@ -1,8 +1,8 @@
 import {
-  ENVIRONMENT_INITIALIZER,
   type EnvironmentProviders,
   makeEnvironmentProviders,
   type Provider,
+  provideEnvironmentInitializer,
 } from '@angular/core';
 
 import {
@@ -23,14 +23,10 @@ export function provideSanity(
           { provide: SANITY_CONFIG, useValue: factoryOrConfig()?.config() },
         ]
       : [{ provide: SANITY_CONFIG, useValue: factoryOrConfig }]),
-    {
-      provide: ENVIRONMENT_INITIALIZER,
-      multi: true,
-      useValue: () => {
-        // This is a placeholder for any initialization logic you might need.
-        // For example, you could set up global error handling for Sanity queries here.
-      },
-    },
+    provideEnvironmentInitializer(() => {
+      // This is a placeholder for any initialization logic you might need.
+      // For example, you could set up global error handling for Sanity queries here.
+    }),
     features.map((feature) => feature.ɵproviders),
   ]);
 }

--- a/packages/sanity/visual-editing/src/optimistic/documents.spec.ts
+++ b/packages/sanity/visual-editing/src/optimistic/documents.spec.ts
@@ -1,0 +1,80 @@
+import type { SanityDocument } from '@sanity/client';
+import type { MutatorActor } from '@sanity/visual-editing/optimistic';
+import { describe, expect, test, vi } from 'vitest';
+
+import { createDocumentsGet } from './documents';
+
+type TestPost = SanityDocument<Record<string, unknown>> & {
+  title: string;
+};
+
+function createMutatorActor(snapshot: TestPost) {
+  const draftDoc = {
+    getSnapshot: vi.fn(() => ({ context: { local: snapshot } })),
+    on: vi.fn(),
+    send: vi.fn(),
+  };
+  const publishedDoc = {
+    getSnapshot: vi.fn(() => ({ context: { local: null } })),
+    on: vi.fn(),
+    send: vi.fn(),
+  };
+  const actor = {
+    getSnapshot: vi.fn(() => ({
+      context: {
+        documents: {
+          'drafts.post-id': draftDoc,
+          'post-id': publishedDoc,
+        },
+      },
+    })),
+  } as unknown as MutatorActor;
+
+  return { actor, draftDoc, publishedDoc };
+}
+
+describe('createDocumentsGet', () => {
+  test('exposes the current document through getSnapshot', async () => {
+    const snapshot = {
+      _createdAt: '2026-01-01T00:00:00.000Z',
+      _id: 'drafts.post-id',
+      _rev: 'rev',
+      _type: 'post',
+      _updatedAt: '2026-01-01T00:00:00.000Z',
+      title: 'Hello',
+    };
+    const { actor } = createMutatorActor(snapshot);
+
+    const document = createDocumentsGet(actor)<TestPost>('post-id');
+
+    await expect(document.getSnapshot()).resolves.toEqual(snapshot);
+  });
+
+  test('resolves patch callbacks and draft creation from getSnapshot', async () => {
+    const snapshot = {
+      _createdAt: '2026-01-01T00:00:00.000Z',
+      _id: 'post-id',
+      _rev: 'rev',
+      _type: 'post',
+      _updatedAt: '2026-01-01T00:00:00.000Z',
+      title: 'Hello',
+    };
+    const { actor, draftDoc } = createMutatorActor(snapshot);
+    const document = createDocumentsGet(actor)<TestPost>('post-id');
+
+    await document.patch(async ({ getSnapshot }) => {
+      await expect(getSnapshot()).resolves.toEqual(snapshot);
+      return [];
+    });
+
+    expect(draftDoc.send).toHaveBeenCalledWith({
+      type: 'mutate',
+      mutations: expect.arrayContaining([
+        expect.objectContaining({
+          document: expect.objectContaining({ _id: 'drafts.post-id' }),
+        }),
+      ]),
+    });
+    expect(draftDoc.send).toHaveBeenCalledWith({ type: 'submit' });
+  });
+});

--- a/packages/sanity/visual-editing/src/optimistic/documents.ts
+++ b/packages/sanity/visual-editing/src/optimistic/documents.ts
@@ -70,10 +70,18 @@ function getDocumentsAndSnapshot<T extends Record<string, any>>(
   });
 
   const getSnapshot = () => snapshotPromise;
+  const getRequiredSnapshot = () => {
+    if (!snapshot) {
+      throw new Error(`Snapshot for document "${id}" not found`);
+    }
+
+    return snapshot;
+  };
 
   return {
     draftDoc: draftDocument,
     draftId,
+    getRequiredSnapshot,
     getSnapshot,
     publishedDoc: publishedDocument,
     publishedId,
@@ -81,11 +89,7 @@ function getDocumentsAndSnapshot<T extends Record<string, any>>(
      * @deprecated - use `getSnapshot` instead
      */
     get snapshot() {
-      if (!snapshot) {
-        throw new Error(`Snapshot for document "${id}" not found`);
-      }
-
-      return snapshot;
+      return getRequiredSnapshot();
     },
   };
 }
@@ -107,7 +111,8 @@ function createDocumentGet<T extends Record<string, any>>(
   return <P extends Path<T, keyof T>>(
     path?: P,
   ): PathValue<T, P> | SanityDocument<T> | undefined => {
-    const { snapshot } = getDocumentsAndSnapshot<T>(id, actor);
+    const { getRequiredSnapshot } = getDocumentsAndSnapshot<T>(id, actor);
+    const snapshot = getRequiredSnapshot();
 
     return path
       ? (getAtPath(snapshot, path) as PathValue<T, P>)
@@ -142,7 +147,7 @@ function createDocumentPatch<T extends Record<string, any>>(
        * @deprecated - use `getSnapshot` instead
        */
       get snapshot() {
-        return result.snapshot;
+        return result.getRequiredSnapshot();
       },
       getSnapshot,
     };

--- a/packages/sanity/visual-editing/src/ui/overlays.component.ts
+++ b/packages/sanity/visual-editing/src/ui/overlays.component.ts
@@ -48,6 +48,12 @@ type RenderElement = ElementState & {
   draggable: boolean;
 };
 
+type NavigatorWithUserAgentData = Navigator & {
+  userAgentData?: {
+    platform?: string;
+  };
+};
+
 function raf2(fn: () => void): () => void {
   let r1: number | undefined;
   const r0 = requestAnimationFrame(() => {
@@ -66,8 +72,16 @@ function isAltKey(event: KeyboardEvent): boolean {
   return event.key === 'Alt';
 }
 
+function isAppleModifierPlatform(navigator: Navigator): boolean {
+  const platform =
+    (navigator as NavigatorWithUserAgentData).userAgentData?.platform ??
+    navigator.userAgent;
+
+  return /Mac|iPod|iPhone|iPad/i.test(platform);
+}
+
 function isHotkey(keys: string[], event: KeyboardEvent): boolean {
-  const isMac = /Mac|iPod|iPhone|iPad/.test(window.navigator.platform);
+  const isMac = isAppleModifierPlatform(window.navigator);
   const modifiers: Record<
     string,
     'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'

--- a/packages/sanity/visual-editing/src/visual-editing-client.component.ts
+++ b/packages/sanity/visual-editing/src/visual-editing-client.component.ts
@@ -191,14 +191,7 @@ export class VisualEditingClientComponent {
       });
   }
 
-  private defaultRefresh: VisualEditingOptions['refresh'] = (payload) => {
-    if (payload.source === 'mutation' && payload.livePreviewEnabled) {
-      console.debug(
-        'Live preview is setup, mutation is skipped assuming its handled by the live preview',
-      );
-      return false;
-    }
-
+  private defaultRefresh: VisualEditingOptions['refresh'] = () => {
     console.debug(
       'No Angular route revalidation hook was provided, refreshing the browser document',
     );


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes # N/A

## What is the new behavior?

Replaces deprecated API usage in the Sanity package:

- Uses Angular `provideEnvironmentInitializer` instead of the deprecated `ENVIRONMENT_INITIALIZER` token.
- Detects Apple modifier-key platforms without `navigator.platform`, preferring `userAgentData.platform` with a `userAgent` fallback.
- Removes reliance on Sanity's deprecated `livePreviewEnabled` refresh payload flag from the default visual-editing refresh handler.
- Routes optimistic document internals through `getSnapshot`/shared snapshot helpers and adds focused test coverage.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Validation:

- `node --input-type=module -e "import { ESLint } from 'eslint'; import config from './eslint.config.js'; import tseslint from 'typescript-eslint'; const eslint = new ESLint({ overrideConfigFile: true, overrideConfig: [...config, { files: ['**/*.ts'], plugins: { '@typescript-eslint': tseslint.plugin }, languageOptions: { parserOptions: { projectService: true, tsconfigRootDir: process.cwd() } }, rules: { '@typescript-eslint/no-deprecated': 'error' } }] }); const results = await eslint.lintFiles(['packages/sanity/**/*.ts']); const messages = results.flatMap(result => result.messages.filter(message => message.ruleId === '@typescript-eslint/no-deprecated').map(message => result.filePath + ':' + message.line + ':' + message.column + ' ' + message.message)); console.log(messages.join('\\n') || 'No deprecated usages reported'); if (messages.length) process.exitCode = 1;"`
- `pnpm --filter @limitless-angular/sanity lint`
- `pnpm --filter @limitless-angular/sanity test`
- `pnpm --filter @limitless-angular/sanity build`

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

N/A
