### PR TITLE
docs(sanity): describe Angular 21 as stable

### DIFF
--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -36,14 +36,9 @@ npm install --save @limitless-angular/sanity @sanity/client
 | 19.x    | 21.x, 20.x, 19.x            |
 | 18.x    | 20.x, 19.x, 18.x            |
 
-The current stable 20.x package line supports Angular 18, Angular 19, and
-Angular 20.
-
-Angular 21 support is available on the `next` prerelease line:
-
-```bash
-npm install @limitless-angular/sanity@next
-```
+The current stable 21.x package line supports Angular 19, Angular 20, and
+Angular 21. Angular 18 remains supported by the 20.x, 19.x, and 18.x package
+lines.
 
 ## Quick Start
 


### PR DESCRIPTION
## PR Checklist

Updates the README compatibility wording now that the v21 package line is stable.

Closes N/A

## What is the new behavior?

- Describes the stable 21.x package line as supporting Angular 19, Angular 20, and Angular 21.
- Removes the obsolete `@next` prerelease install guidance for Angular 21.
- Notes that Angular 18 remains supported by the 20.x, 19.x, and 18.x package lines.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Testing:

- [x] `pnpm exec prettier --check packages/sanity/README.md`
- [x] `git diff --check`

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

N/A