### PR TITLE
ci(release): publish from verified release intents

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -3,15 +3,39 @@ name: Release and Publish
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version to publish (optional - will use conventional commits if not specified)'
-        required: false
-        default: ''
-      prerelease:
-        description: 'Infer or coerce the release as a next prerelease'
+      release_intent:
+        description: 'Release intent to publish'
+        required: true
+        default: stable
+        type: choice
+        options:
+          - stable
+          - prerelease
+          - promote-stable
+          - manual
+      bump:
+        description: 'Version bump for stable or prerelease intents'
+        required: true
+        default: auto
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+      allow_major_without_prerelease:
+        description: 'Allow a stable major release without a prerelease train'
         required: false
         default: false
         type: boolean
+      manual_version:
+        description: 'Exact semver version when release_intent is manual'
+        required: false
+        default: ''
+      manual_reason:
+        description: 'Reason when release_intent is manual'
+        required: false
+        default: ''
       verbose:
         description: 'Enable verbose logging'
         required: false
@@ -26,14 +50,183 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  validate-release:
+    if: github.repository == 'limitless-angular/limitless-angular' && github.ref == 'refs/heads/main'
+    name: Validate Release Plan
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    outputs:
+      release-plan: ${{ steps.plan.outputs.release-plan }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v6
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Install Node.js per package.json
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: 'pnpm'
+          registry-url: https://registry.npmjs.org/
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Verify environment
+        run: |
+          echo "Node version: $(node -v)"
+          echo "pnpm version: $(pnpm -v)"
+          echo "Workspace directory: $(pwd)"
+
+      - name: Configure release paths
+        run: |
+          echo "RELEASE_PLAN_PATH=$RUNNER_TEMP/release-plan.json" >> "$GITHUB_ENV"
+          echo "RELEASE_NOTES_PATH=$RUNNER_TEMP/release-notes.md" >> "$GITHUB_ENV"
+
+      - name: Compute release plan
+        id: plan
+        env:
+          RELEASE_ALLOW_MAJOR_WITHOUT_PRERELEASE: ${{ inputs.allow_major_without_prerelease }}
+          RELEASE_BUMP: ${{ inputs.bump }}
+          RELEASE_INTENT: ${{ inputs.release_intent }}
+          RELEASE_MANUAL_REASON: ${{ inputs.manual_reason }}
+          RELEASE_MANUAL_VERSION: ${{ inputs.manual_version }}
+        run: |
+          PLAN_ARGS=(--intent "$RELEASE_INTENT" --bump "$RELEASE_BUMP")
+          if [ "$RELEASE_ALLOW_MAJOR_WITHOUT_PRERELEASE" = "true" ]; then
+            PLAN_ARGS+=(--allow-major-without-prerelease)
+          fi
+          if [ -n "$RELEASE_MANUAL_VERSION" ]; then
+            PLAN_ARGS+=(--manual-version "$RELEASE_MANUAL_VERSION")
+          fi
+          if [ -n "$RELEASE_MANUAL_REASON" ]; then
+            PLAN_ARGS+=(--manual-reason "$RELEASE_MANUAL_REASON")
+          fi
+
+          pnpm --filter=@limitless-angular/release-tools run --silent release:plan "${PLAN_ARGS[@]}" --json > "$RELEASE_PLAN_PATH"
+          cat "$RELEASE_PLAN_PATH"
+          pnpm --filter=@limitless-angular/release-tools run --silent release:notes "${PLAN_ARGS[@]}" > "$RELEASE_NOTES_PATH"
+          cat "$RELEASE_NOTES_PATH"
+
+          node <<'NODE'
+          const fs = require('node:fs');
+          const plan = JSON.parse(fs.readFileSync(process.env.RELEASE_PLAN_PATH, 'utf8'));
+
+          fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `release-plan<<RELEASE_PLAN_JSON\n${JSON.stringify(plan)}\nRELEASE_PLAN_JSON\n`,
+          );
+          NODE
+
+      - name: Run tests
+        run: pnpm turbo run test
+
+      - name: Check for lint errors
+        run: pnpm turbo run lint --filter=@limitless-angular/sanity
+
+      - name: Validate release dry run
+        id: release
+        env:
+          RELEASE_ALLOW_MAJOR_WITHOUT_PRERELEASE: ${{ inputs.allow_major_without_prerelease }}
+          RELEASE_BUMP: ${{ inputs.bump }}
+          RELEASE_INTENT: ${{ inputs.release_intent }}
+          RELEASE_MANUAL_REASON: ${{ inputs.manual_reason }}
+          RELEASE_MANUAL_VERSION: ${{ inputs.manual_version }}
+          RELEASE_VERBOSE: ${{ inputs.verbose }}
+        run: |
+          PIPELINE_ARGS=(--intent "$RELEASE_INTENT" --bump "$RELEASE_BUMP")
+          if [ "$RELEASE_ALLOW_MAJOR_WITHOUT_PRERELEASE" = "true" ]; then
+            PIPELINE_ARGS+=(--allow-major-without-prerelease)
+          fi
+          if [ -n "$RELEASE_MANUAL_VERSION" ]; then
+            PIPELINE_ARGS+=(--manual-version "$RELEASE_MANUAL_VERSION")
+          fi
+          if [ -n "$RELEASE_MANUAL_REASON" ]; then
+            PIPELINE_ARGS+=(--manual-reason "$RELEASE_MANUAL_REASON")
+          fi
+          if [ "$RELEASE_VERBOSE" = "true" ]; then
+            PIPELINE_ARGS+=(--verbose)
+          fi
+
+          pnpm turbo run release:dry-run --filter=@limitless-angular/release-tools -- "${PIPELINE_ARGS[@]}"
+
+      - name: Generate release validation summary
+        if: always()
+        env:
+          RELEASE_ALLOW_MAJOR_WITHOUT_PRERELEASE: ${{ inputs.allow_major_without_prerelease }}
+          RELEASE_BUMP: ${{ inputs.bump }}
+          RELEASE_INTENT: ${{ inputs.release_intent }}
+          RELEASE_MANUAL_VERSION: ${{ inputs.manual_version }}
+          RELEASE_MODE: validation
+          RELEASE_OUTCOME: ${{ steps.release.outcome || 'skipped' }}
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+
+          const planPath = process.env.RELEASE_PLAN_PATH;
+          const notesPath = process.env.RELEASE_NOTES_PATH;
+          const lines = [
+            '## Release Validation Summary',
+            '',
+            `- Mode: ${process.env.RELEASE_MODE}`,
+            `- Outcome: ${process.env.RELEASE_OUTCOME}`,
+            `- Release intent input: ${process.env.RELEASE_INTENT}`,
+            `- Bump input: ${process.env.RELEASE_BUMP}`,
+            `- Allow major without prerelease: ${process.env.RELEASE_ALLOW_MAJOR_WITHOUT_PRERELEASE}`,
+            `- Manual version input: ${process.env.RELEASE_MANUAL_VERSION || 'none'}`,
+          ];
+
+          if (planPath && fs.existsSync(planPath)) {
+            const plan = JSON.parse(fs.readFileSync(planPath, 'utf8'));
+
+            lines.push(
+              `- Package: ${plan.packageName}`,
+              `- Release intent: ${plan.releaseIntent}`,
+              `- Release bump: ${plan.releaseBump}`,
+              `- Planned version: ${plan.nextVersion}`,
+              `- Release tag: ${plan.releaseTag}`,
+              `- npm dist-tag: ${plan.npmDistTag}`,
+              `- Head SHA: ${plan.headSha || 'unknown'}`,
+              `- Commit count: ${plan.commitCount}`,
+              `- Release notes base tag: ${plan.releaseNotesBaseTag || 'none'}`,
+              `- Release note commit count: ${plan.releaseNotesCommitCount}`,
+            );
+          } else {
+            lines.push('- Planned version: unavailable; release planning did not complete.');
+          }
+
+          if (notesPath && fs.existsSync(notesPath)) {
+            const notes = fs.readFileSync(notesPath, 'utf8').trimEnd();
+
+            lines.push(
+              '',
+              '## Future GitHub Release Notes',
+              '',
+              notes || '_No release notes were generated._',
+            );
+          }
+
+          fs.writeFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join('\n')}\n`);
+          NODE
+
   release-and-publish:
+    needs: validate-release
     if: github.repository == 'limitless-angular/limitless-angular' && github.ref == 'refs/heads/main'
     name: Release and Publish to npm
     runs-on: ubuntu-22.04
     permissions:
       contents: write
       id-token: write
-    environment: npm-release
+    environment:
+      name: npm-release
+      url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -70,54 +263,94 @@ jobs:
           echo "GitHub Actions OIDC request environment: available"
 
       - name: Configure release paths
-        run: echo "RELEASE_PLAN_PATH=$RUNNER_TEMP/release-plan.json" >> "$GITHUB_ENV"
+        run: |
+          echo "RELEASE_PLAN_PATH=$RUNNER_TEMP/release-plan.json" >> "$GITHUB_ENV"
+          echo "VALIDATED_RELEASE_PLAN_PATH=$RUNNER_TEMP/validated-release-plan.json" >> "$GITHUB_ENV"
 
-      - name: Run tests
-        run: pnpm turbo run test
+      - name: Restore validated release plan
+        env:
+          VALIDATED_RELEASE_PLAN: ${{ needs.validate-release.outputs.release-plan }}
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
 
-      - name: Check for lint errors
-        run: pnpm turbo run lint --filter=@limitless-angular/sanity
+          if (!process.env.VALIDATED_RELEASE_PLAN) {
+            throw new Error('Missing validated release plan from validation job.');
+          }
+
+          fs.writeFileSync(
+            process.env.VALIDATED_RELEASE_PLAN_PATH,
+            `${process.env.VALIDATED_RELEASE_PLAN}\n`,
+          );
+          NODE
+
+      - name: Verify release plan did not change
+        id: verify
+        env:
+          RELEASE_ALLOW_MAJOR_WITHOUT_PRERELEASE: ${{ inputs.allow_major_without_prerelease }}
+          RELEASE_BUMP: ${{ inputs.bump }}
+          RELEASE_INTENT: ${{ inputs.release_intent }}
+          RELEASE_MANUAL_REASON: ${{ inputs.manual_reason }}
+          RELEASE_MANUAL_VERSION: ${{ inputs.manual_version }}
+        run: |
+          PLAN_ARGS=(--intent "$RELEASE_INTENT" --bump "$RELEASE_BUMP")
+          if [ "$RELEASE_ALLOW_MAJOR_WITHOUT_PRERELEASE" = "true" ]; then
+            PLAN_ARGS+=(--allow-major-without-prerelease)
+          fi
+          if [ -n "$RELEASE_MANUAL_VERSION" ]; then
+            PLAN_ARGS+=(--manual-version "$RELEASE_MANUAL_VERSION")
+          fi
+          if [ -n "$RELEASE_MANUAL_REASON" ]; then
+            PLAN_ARGS+=(--manual-reason "$RELEASE_MANUAL_REASON")
+          fi
+
+          pnpm --filter=@limitless-angular/release-tools run --silent release:plan "${PLAN_ARGS[@]}" --json > "$RELEASE_PLAN_PATH"
+          cat "$RELEASE_PLAN_PATH"
+
+          pnpm --filter=@limitless-angular/release-tools run --silent release:verify-plan --expected "$VALIDATED_RELEASE_PLAN_PATH" --actual "$RELEASE_PLAN_PATH"
 
       - name: Set up Git user
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
 
-      - name: Validate and publish release
+      - name: Publish release
         id: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          RELEASE_ALLOW_MAJOR_WITHOUT_PRERELEASE: ${{ inputs.allow_major_without_prerelease }}
+          RELEASE_BUMP: ${{ inputs.bump }}
+          RELEASE_INTENT: ${{ inputs.release_intent }}
+          RELEASE_MANUAL_REASON: ${{ inputs.manual_reason }}
+          RELEASE_MANUAL_VERSION: ${{ inputs.manual_version }}
           RELEASE_VERBOSE: ${{ inputs.verbose }}
-          RELEASE_VERSION: ${{ inputs.version }}
-          RELEASE_PRERELEASE: ${{ inputs.prerelease }}
         run: |
-          PLAN_ARGS=()
-          PIPELINE_ARGS=()
-          if [ -n "$RELEASE_VERSION" ]; then
-            PLAN_ARGS+=(--version "$RELEASE_VERSION")
-            PIPELINE_ARGS+=(--version "$RELEASE_VERSION")
+          PIPELINE_ARGS=(--intent "$RELEASE_INTENT" --bump "$RELEASE_BUMP")
+          if [ "$RELEASE_ALLOW_MAJOR_WITHOUT_PRERELEASE" = "true" ]; then
+            PIPELINE_ARGS+=(--allow-major-without-prerelease)
           fi
-          if [ "$RELEASE_PRERELEASE" = "true" ]; then
-            PLAN_ARGS+=(--prerelease)
-            PIPELINE_ARGS+=(--prerelease)
+          if [ -n "$RELEASE_MANUAL_VERSION" ]; then
+            PIPELINE_ARGS+=(--manual-version "$RELEASE_MANUAL_VERSION")
+          fi
+          if [ -n "$RELEASE_MANUAL_REASON" ]; then
+            PIPELINE_ARGS+=(--manual-reason "$RELEASE_MANUAL_REASON")
           fi
           if [ "$RELEASE_VERBOSE" = "true" ]; then
             PIPELINE_ARGS+=(--verbose)
           fi
-
-          pnpm --filter=@limitless-angular/release-tools run --silent release:plan "${PLAN_ARGS[@]}" --json > "$RELEASE_PLAN_PATH"
-          cat "$RELEASE_PLAN_PATH"
 
           pnpm turbo run release:publish --filter=@limitless-angular/release-tools -- "${PIPELINE_ARGS[@]}"
 
       - name: Generate release summary
         if: always()
         env:
+          RELEASE_ALLOW_MAJOR_WITHOUT_PRERELEASE: ${{ inputs.allow_major_without_prerelease }}
+          RELEASE_BUMP: ${{ inputs.bump }}
+          RELEASE_INTENT: ${{ inputs.release_intent }}
+          RELEASE_MANUAL_VERSION: ${{ inputs.manual_version }}
           RELEASE_MODE: publish
-          RELEASE_OUTCOME: ${{ steps.release.outcome }}
-          RELEASE_VERSION: ${{ inputs.version }}
-          RELEASE_PRERELEASE: ${{ inputs.prerelease }}
+          RELEASE_OUTCOME: ${{ steps.release.outcome || 'skipped' }}
         run: |
           node <<'NODE'
           const fs = require('node:fs');
@@ -128,8 +361,10 @@ jobs:
             '',
             `- Mode: ${process.env.RELEASE_MODE}`,
             `- Outcome: ${process.env.RELEASE_OUTCOME}`,
-            `- Version input: ${process.env.RELEASE_VERSION || 'conventional commits'}`,
-            `- Prerelease input: ${process.env.RELEASE_PRERELEASE}`,
+            `- Release intent input: ${process.env.RELEASE_INTENT}`,
+            `- Bump input: ${process.env.RELEASE_BUMP}`,
+            `- Allow major without prerelease: ${process.env.RELEASE_ALLOW_MAJOR_WITHOUT_PRERELEASE}`,
+            `- Manual version input: ${process.env.RELEASE_MANUAL_VERSION || 'none'}`,
           ];
 
           if (planPath && fs.existsSync(planPath)) {
@@ -137,9 +372,12 @@ jobs:
 
             lines.push(
               `- Package: ${plan.packageName}`,
+              `- Release intent: ${plan.releaseIntent}`,
+              `- Release bump: ${plan.releaseBump}`,
               `- Planned version: ${plan.nextVersion}`,
               `- Release tag: ${plan.releaseTag}`,
               `- npm dist-tag: ${plan.npmDistTag}`,
+              `- Head SHA: ${plan.headSha || 'unknown'}`,
               `- Commit count: ${plan.commitCount}`,
               `- Release notes base tag: ${plan.releaseNotesBaseTag || 'none'}`,
               `- Release note commit count: ${plan.releaseNotesCommitCount}`,

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -3,15 +3,39 @@ name: Release Dry Run
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version to validate (optional - will use conventional commits if not specified)'
-        required: false
-        default: ''
-      prerelease:
-        description: 'Infer or coerce the release as a next prerelease'
+      release_intent:
+        description: 'Release intent to validate'
+        required: true
+        default: stable
+        type: choice
+        options:
+          - stable
+          - prerelease
+          - promote-stable
+          - manual
+      bump:
+        description: 'Version bump for stable or prerelease intents'
+        required: true
+        default: auto
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+      allow_major_without_prerelease:
+        description: 'Allow a stable major release without a prerelease train'
         required: false
         default: false
         type: boolean
+      manual_version:
+        description: 'Exact semver version when release_intent is manual'
+        required: false
+        default: ''
+      manual_reason:
+        description: 'Reason when release_intent is manual'
+        required: false
+        default: ''
       verbose:
         description: 'Enable verbose logging'
         required: false
@@ -60,7 +84,9 @@ jobs:
           echo "Workspace directory: $(pwd)"
 
       - name: Configure release paths
-        run: echo "RELEASE_PLAN_PATH=$RUNNER_TEMP/release-plan.json" >> "$GITHUB_ENV"
+        run: |
+          echo "RELEASE_PLAN_PATH=$RUNNER_TEMP/release-plan.json" >> "$GITHUB_ENV"
+          echo "RELEASE_NOTES_PATH=$RUNNER_TEMP/release-notes.md" >> "$GITHUB_ENV"
 
       - name: Run tests
         run: pnpm turbo run test
@@ -71,19 +97,26 @@ jobs:
       - name: Validate release dry run
         id: release
         env:
+          RELEASE_ALLOW_MAJOR_WITHOUT_PRERELEASE: ${{ inputs.allow_major_without_prerelease }}
+          RELEASE_BUMP: ${{ inputs.bump }}
+          RELEASE_INTENT: ${{ inputs.release_intent }}
+          RELEASE_MANUAL_REASON: ${{ inputs.manual_reason }}
+          RELEASE_MANUAL_VERSION: ${{ inputs.manual_version }}
           RELEASE_VERBOSE: ${{ inputs.verbose }}
-          RELEASE_VERSION: ${{ inputs.version }}
-          RELEASE_PRERELEASE: ${{ inputs.prerelease }}
         run: |
-          PLAN_ARGS=()
-          PIPELINE_ARGS=()
-          if [ -n "$RELEASE_VERSION" ]; then
-            PLAN_ARGS+=(--version "$RELEASE_VERSION")
-            PIPELINE_ARGS+=(--version "$RELEASE_VERSION")
+          PLAN_ARGS=(--intent "$RELEASE_INTENT" --bump "$RELEASE_BUMP")
+          PIPELINE_ARGS=(--intent "$RELEASE_INTENT" --bump "$RELEASE_BUMP")
+          if [ "$RELEASE_ALLOW_MAJOR_WITHOUT_PRERELEASE" = "true" ]; then
+            PLAN_ARGS+=(--allow-major-without-prerelease)
+            PIPELINE_ARGS+=(--allow-major-without-prerelease)
           fi
-          if [ "$RELEASE_PRERELEASE" = "true" ]; then
-            PLAN_ARGS+=(--prerelease)
-            PIPELINE_ARGS+=(--prerelease)
+          if [ -n "$RELEASE_MANUAL_VERSION" ]; then
+            PLAN_ARGS+=(--manual-version "$RELEASE_MANUAL_VERSION")
+            PIPELINE_ARGS+=(--manual-version "$RELEASE_MANUAL_VERSION")
+          fi
+          if [ -n "$RELEASE_MANUAL_REASON" ]; then
+            PLAN_ARGS+=(--manual-reason "$RELEASE_MANUAL_REASON")
+            PIPELINE_ARGS+=(--manual-reason "$RELEASE_MANUAL_REASON")
           fi
           if [ "$RELEASE_VERBOSE" = "true" ]; then
             PIPELINE_ARGS+=(--verbose)
@@ -91,28 +124,35 @@ jobs:
 
           pnpm --filter=@limitless-angular/release-tools run --silent release:plan "${PLAN_ARGS[@]}" --json > "$RELEASE_PLAN_PATH"
           cat "$RELEASE_PLAN_PATH"
+          pnpm --filter=@limitless-angular/release-tools run --silent release:notes "${PLAN_ARGS[@]}" > "$RELEASE_NOTES_PATH"
+          cat "$RELEASE_NOTES_PATH"
 
           pnpm turbo run release:dry-run --filter=@limitless-angular/release-tools -- "${PIPELINE_ARGS[@]}"
 
       - name: Generate release dry-run summary
         if: always()
         env:
+          RELEASE_ALLOW_MAJOR_WITHOUT_PRERELEASE: ${{ inputs.allow_major_without_prerelease }}
+          RELEASE_BUMP: ${{ inputs.bump }}
+          RELEASE_INTENT: ${{ inputs.release_intent }}
+          RELEASE_MANUAL_VERSION: ${{ inputs.manual_version }}
           RELEASE_MODE: dry-run
           RELEASE_OUTCOME: ${{ steps.release.outcome }}
-          RELEASE_VERSION: ${{ inputs.version }}
-          RELEASE_PRERELEASE: ${{ inputs.prerelease }}
         run: |
           node <<'NODE'
           const fs = require('node:fs');
 
           const planPath = process.env.RELEASE_PLAN_PATH;
+          const notesPath = process.env.RELEASE_NOTES_PATH;
           const lines = [
             '## Release Dry Run Summary',
             '',
             `- Mode: ${process.env.RELEASE_MODE}`,
             `- Outcome: ${process.env.RELEASE_OUTCOME}`,
-            `- Version input: ${process.env.RELEASE_VERSION || 'conventional commits'}`,
-            `- Prerelease input: ${process.env.RELEASE_PRERELEASE}`,
+            `- Release intent input: ${process.env.RELEASE_INTENT}`,
+            `- Bump input: ${process.env.RELEASE_BUMP}`,
+            `- Allow major without prerelease: ${process.env.RELEASE_ALLOW_MAJOR_WITHOUT_PRERELEASE}`,
+            `- Manual version input: ${process.env.RELEASE_MANUAL_VERSION || 'none'}`,
           ];
 
           if (planPath && fs.existsSync(planPath)) {
@@ -120,15 +160,29 @@ jobs:
 
             lines.push(
               `- Package: ${plan.packageName}`,
+              `- Release intent: ${plan.releaseIntent}`,
+              `- Release bump: ${plan.releaseBump}`,
               `- Planned version: ${plan.nextVersion}`,
               `- Release tag: ${plan.releaseTag}`,
               `- npm dist-tag: ${plan.npmDistTag}`,
+              `- Head SHA: ${plan.headSha || 'unknown'}`,
               `- Commit count: ${plan.commitCount}`,
               `- Release notes base tag: ${plan.releaseNotesBaseTag || 'none'}`,
               `- Release note commit count: ${plan.releaseNotesCommitCount}`,
             );
           } else {
             lines.push('- Planned version: unavailable; release planning did not complete.');
+          }
+
+          if (notesPath && fs.existsSync(notesPath)) {
+            const notes = fs.readFileSync(notesPath, 'utf8').trimEnd();
+
+            lines.push(
+              '',
+              '## Future GitHub Release Notes',
+              '',
+              notes || '_No release notes were generated._',
+            );
           }
 
           fs.writeFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join('\n')}\n`);

--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
     "format:write": "prettier --write .",
     "release": "pnpm turbo run release --filter=@limitless-angular/release-tools --",
     "release:dry-run": "pnpm turbo run release:dry-run --filter=@limitless-angular/release-tools --",
+    "release:notes": "pnpm --filter=@limitless-angular/release-tools run --silent release:notes",
     "release:plan": "pnpm --filter=@limitless-angular/release-tools run --silent release:plan",
-    "release:publish": "pnpm turbo run release:publish --filter=@limitless-angular/release-tools --"
+    "release:publish": "pnpm turbo run release:publish --filter=@limitless-angular/release-tools --",
+    "release:verify-plan": "pnpm --filter=@limitless-angular/release-tools run --silent release:verify-plan"
   },
   "packageManager": "pnpm@11.5.2",
   "volta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -561,6 +561,9 @@ importers:
       '@playwright/test':
         specifier: 1.44.1
         version: 1.44.1
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
   tools/release:
     dependencies:

--- a/tools/angular-compat/orchestration-contract.test.mjs
+++ b/tools/angular-compat/orchestration-contract.test.mjs
@@ -216,10 +216,7 @@ test('release workflows delegate to the release tools package', () => {
   const publishWorkflow = readWorkspaceWorkflow(publishWorkflowPath);
   const dryRunWorkflow = readWorkspaceWorkflow(dryRunWorkflowPath);
   const validateJob = getWorkflowJob(publishWorkflow, 'validate-release');
-  const publishJob = getWorkflowJob(
-    publishWorkflow,
-    'release-and-publish',
-  );
+  const publishJob = getWorkflowJob(publishWorkflow, 'release-and-publish');
   const dryRunJob = getWorkflowJob(dryRunWorkflow, 'release-dry-run');
   const validateSetupNodeStep = getWorkflowStep(
     validateJob,

--- a/tools/angular-compat/orchestration-contract.test.mjs
+++ b/tools/angular-compat/orchestration-contract.test.mjs
@@ -3,6 +3,8 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { test } from 'node:test';
 
+import { parse as parseYaml } from 'yaml';
+
 import { readJson, workspaceRoot } from './lib.mjs';
 
 const compatPackageName = '@limitless-angular/angular-compat';
@@ -43,10 +45,12 @@ const rootReleaseScriptContract = {
   'release:dry-run': turboReleaseCommand('release:dry-run', {
     forwardsArgs: true,
   }),
+  'release:notes': `pnpm --filter=${releasePackageName} run --silent release:notes`,
   'release:plan': `pnpm --filter=${releasePackageName} run --silent release:plan`,
   'release:publish': turboReleaseCommand('release:publish', {
     forwardsArgs: true,
   }),
+  'release:verify-plan': `pnpm --filter=${releasePackageName} run --silent release:verify-plan`,
 };
 
 const packageScriptContract = {
@@ -205,6 +209,81 @@ test('autofix workflow prepares built packages before preview publishing', () =>
 });
 
 test('release workflows delegate to the release tools package', () => {
+  const publishWorkflowPath = '.github/workflows/release-and-publish.yml';
+  const dryRunWorkflowPath = '.github/workflows/release-dry-run.yml';
+  const publishWorkflowText = readWorkspaceText(publishWorkflowPath);
+  const dryRunWorkflowText = readWorkspaceText(dryRunWorkflowPath);
+  const publishWorkflow = readWorkspaceWorkflow(publishWorkflowPath);
+  const dryRunWorkflow = readWorkspaceWorkflow(dryRunWorkflowPath);
+  const validateJob = getWorkflowJob(publishWorkflow, 'validate-release');
+  const publishJob = getWorkflowJob(
+    publishWorkflow,
+    'release-and-publish',
+  );
+  const dryRunJob = getWorkflowJob(dryRunWorkflow, 'release-dry-run');
+  const validateSetupNodeStep = getWorkflowStep(
+    validateJob,
+    'Install Node.js per package.json',
+  );
+  const publishSetupNodeStep = getWorkflowStep(
+    publishJob,
+    'Install Node.js per package.json',
+  );
+
+  assert.equal(publishJob.needs, 'validate-release');
+  assert.equal(getWorkflowEnvironmentName(publishJob), 'npm-release');
+  assert.equal(
+    publishJob.environment.url,
+    '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}',
+  );
+  assert.equal(publishJob.permissions['id-token'], 'write');
+  assert.equal(publishJob.permissions.contents, 'write');
+  assert.equal(validateJob.permissions.contents, 'read');
+  assert.equal(dryRunJob.permissions.contents, 'read');
+  assert.equal(
+    validateSetupNodeStep.with?.['registry-url'],
+    'https://registry.npmjs.org/',
+  );
+  assert.equal(
+    publishSetupNodeStep.with?.['registry-url'],
+    undefined,
+    'trusted publishing job must not configure npm auth through setup-node',
+  );
+
+  assertJobRuns(validateJob, [
+    `pnpm --filter=${releasePackageName} run --silent release:plan`,
+    `pnpm --filter=${releasePackageName} run --silent release:notes`,
+    turboReleaseCommand('release:dry-run', { forwardsArgs: true }),
+  ]);
+  assertJobRuns(publishJob, [
+    'npm install -g npm@^11.10.0',
+    `pnpm --filter=${releasePackageName} run --silent release:plan`,
+    `pnpm --filter=${releasePackageName} run --silent release:verify-plan`,
+    turboReleaseCommand('release:publish', { forwardsArgs: true }),
+  ]);
+  assertJobRuns(dryRunJob, [
+    `pnpm --filter=${releasePackageName} run --silent release:plan`,
+    `pnpm --filter=${releasePackageName} run --silent release:notes`,
+    turboReleaseCommand('release:dry-run', { forwardsArgs: true }),
+  ]);
+
+  assertIncludes(publishWorkflowText, [
+    'NPM_CONFIG_PROVENANCE: true',
+    'Future GitHub Release Notes',
+  ]);
+  assertIncludes(dryRunWorkflowText, ['Future GitHub Release Notes']);
+
+  assert.doesNotMatch(publishWorkflowText, /runner\.temp/);
+  assert.doesNotMatch(publishWorkflowText, /compat:pack/);
+  assert.doesNotMatch(publishWorkflowText, /npm publish/);
+  assert.doesNotMatch(publishWorkflowText, /NODE_AUTH_TOKEN/);
+  assert.doesNotMatch(publishWorkflowText, /NPM_ACCESS_TOKEN/);
+  assert.doesNotMatch(dryRunWorkflowText, /runner\.temp/);
+  assert.doesNotMatch(dryRunWorkflowText, /NODE_AUTH_TOKEN/);
+  assert.doesNotMatch(dryRunWorkflowText, /NPM_ACCESS_TOKEN/);
+});
+
+test('legacy release workflow text contract remains documented', () => {
   const publishWorkflow = readWorkspaceText(
     '.github/workflows/release-and-publish.yml',
   );
@@ -213,29 +292,11 @@ test('release workflows delegate to the release tools package', () => {
   );
 
   assertIncludes(publishWorkflow, [
-    turboReleaseCommand('release:publish', { forwardsArgs: true }),
-    'environment: npm-release',
-    'id-token: write',
     'echo "RELEASE_PLAN_PATH=$RUNNER_TEMP/release-plan.json" >> "$GITHUB_ENV"',
-    'npm install -g npm@^11.10.0',
-    'NPM_CONFIG_PROVENANCE: true',
   ]);
   assertIncludes(dryRunWorkflow, [
-    turboReleaseCommand('release:dry-run', { forwardsArgs: true }),
-    'permissions:',
-    'contents: read',
     'echo "RELEASE_PLAN_PATH=$RUNNER_TEMP/release-plan.json" >> "$GITHUB_ENV"',
   ]);
-
-  assert.doesNotMatch(publishWorkflow, /runner\.temp/);
-  assert.doesNotMatch(publishWorkflow, /compat:pack/);
-  assert.doesNotMatch(publishWorkflow, /npm publish/);
-  assert.doesNotMatch(publishWorkflow, /registry-url/);
-  assert.doesNotMatch(publishWorkflow, /NODE_AUTH_TOKEN/);
-  assert.doesNotMatch(publishWorkflow, /NPM_ACCESS_TOKEN/);
-  assert.doesNotMatch(dryRunWorkflow, /runner\.temp/);
-  assert.doesNotMatch(dryRunWorkflow, /NODE_AUTH_TOKEN/);
-  assert.doesNotMatch(dryRunWorkflow, /NPM_ACCESS_TOKEN/);
 });
 
 test('release tools package owns the release command mapping', () => {
@@ -245,15 +306,19 @@ test('release tools package owns the release command mapping', () => {
     pick(scripts, [
       'release',
       'release:dry-run',
+      'release:notes',
       'release:plan',
       'release:publish',
+      'release:verify-plan',
       'test',
     ]),
     {
       release: 'node cli.mjs run',
       'release:dry-run': 'node cli.mjs dry-run',
+      'release:notes': 'node cli.mjs notes',
       'release:plan': 'node cli.mjs plan',
       'release:publish': 'node cli.mjs publish',
+      'release:verify-plan': 'node cli.mjs verify-plan',
       test: 'node --test src/*.test.mjs',
     },
   );
@@ -296,6 +361,41 @@ function readWorkspaceJson(path) {
 
 function readWorkspaceText(path) {
   return readFileSync(join(workspaceRoot, path), 'utf8');
+}
+
+function readWorkspaceWorkflow(path) {
+  return parseYaml(readWorkspaceText(path));
+}
+
+function getWorkflowJob(workflow, jobName) {
+  const job = workflow.jobs?.[jobName];
+
+  assert.ok(job, `Expected workflow job: ${jobName}`);
+
+  return job;
+}
+
+function getWorkflowEnvironmentName(job) {
+  return typeof job.environment === 'string'
+    ? job.environment
+    : job.environment?.name;
+}
+
+function getWorkflowStep(job, stepName) {
+  const step = job.steps.find((candidate) => candidate.name === stepName);
+
+  assert.ok(step, `Expected workflow step: ${stepName}`);
+
+  return step;
+}
+
+function assertJobRuns(job, expectedSnippets) {
+  const runScripts = job.steps
+    .map((step) => step.run)
+    .filter((run) => typeof run === 'string')
+    .join('\n');
+
+  assertIncludes(runScripts, expectedSnippets);
 }
 
 function pick(object, keys) {

--- a/tools/angular-compat/package.json
+++ b/tools/angular-compat/package.json
@@ -22,6 +22,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
-    "@playwright/test": "1.44.1"
+    "@playwright/test": "1.44.1",
+    "yaml": "^2.9.0"
   }
 }

--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -9,29 +9,50 @@ workspace and call this package.
 Plan a release without changing files:
 
 ```bash
-pnpm run release:plan --version patch
-pnpm run release:plan --version 19.3.0 --json
-pnpm run release:plan --prerelease
+pnpm run release:plan -- --intent stable --bump auto
+pnpm run release:plan -- --intent prerelease --bump major
+pnpm run release:plan -- --intent promote-stable --json
+```
+
+Preview the GitHub Release notes for the same plan:
+
+```bash
+pnpm run release:notes -- --intent stable --bump auto
+pnpm run release:notes -- --intent promote-stable
 ```
 
 Validate a prospective release without publishing:
 
 ```bash
-pnpm run release:dry-run --version patch
-pnpm run release:dry-run --prerelease
+pnpm run release:dry-run -- --intent stable --bump auto
+pnpm run release:dry-run -- --intent prerelease --bump major
 ```
 
 Publish a release:
 
 ```bash
-pnpm turbo run release:publish --filter=@limitless-angular/release-tools -- --version patch
-pnpm turbo run release:publish --filter=@limitless-angular/release-tools -- --prerelease
+pnpm turbo run release:publish --filter=@limitless-angular/release-tools -- --intent stable --bump auto
+pnpm turbo run release:publish --filter=@limitless-angular/release-tools -- --intent promote-stable
 ```
 
-Prerelease mode infers the release level from package-relevant conventional
-commits and uses the `next` prerelease identifier. For example, a feature-level
-release from `19.2.0` becomes `19.3.0-next.0`; the next prerelease in that train
-becomes `19.3.0-next.1`.
+Release planning is intent-based. Maintainers choose the kind of release; the
+tool computes the exact version:
+
+- `stable` publishes to npm's `latest` dist-tag. `--bump auto` derives
+  `patch`, `minor`, or `major` from package-relevant conventional commits.
+- `prerelease` publishes to npm's `next` dist-tag with the `next` prerelease
+  identifier. For example, `--intent prerelease --bump major` from `21.0.0`
+  becomes `22.0.0-next.0`; the next prerelease in that train becomes
+  `22.0.0-next.1`.
+- `promote-stable` promotes the latest prerelease train to stable without a
+  human typing the version. For example, `22.0.0-next.1` becomes `22.0.0`.
+- `manual` is an escape hatch that requires `--manual-version` and
+  `--manual-reason`.
+
+Stable major releases without a prerelease train are blocked unless maintainers
+explicitly pass `--allow-major-without-prerelease`. If the latest reachable
+release tag is a prerelease, `stable` refuses to guess; use `promote-stable` to
+publish that train as stable.
 
 ## Source of Truth
 
@@ -62,6 +83,9 @@ Release planning is package-aware. Each releasable package is configured in
 - `ignoredReleaseScopeJsonFields`: top-level JSON fields that ignored
   infrastructure scopes may touch without inferring a package release.
 - `releaseTagPrefix`: the Git tag prefix for that package's versions.
+- `stablePromotionIgnoredPaths`: package-owned documentation paths that may
+  change after a prerelease without requiring another prerelease before stable
+  promotion.
 
 The planner derives inferred versions from commits that either touch a
 configured package path or use a configured package scope. For
@@ -73,7 +97,8 @@ releases, even when they touch configured source-only package metadata. For
 `version` and `private` are ignored this way; consumer-facing manifest changes
 such as dependency, peer dependency, or export updates still infer a release.
 Source changes still infer releases by path, even if their conventional commit
-scope is wrong. Maintainers can always pass an explicit `--version`.
+scope is wrong. Maintainers can use the `manual` release intent when the normal
+state machine cannot represent an exceptional recovery release.
 
 GitHub Release notes use the same package-relevance filter, but their base tag
 depends on the release type. Prerelease notes are incremental from the latest
@@ -88,7 +113,7 @@ one.
 Both dry-run and publish mode use the same release pipeline:
 
 1. Compute the release plan from the latest reachable `sanity@*` tag, explicit
-   version input, or package-relevant conventional commits. Stable GitHub
+   release intent, or package-relevant conventional commits. Stable GitHub
    Release notes use the latest stable tag as their base so final releases
    summarize their prerelease train.
 2. In publish mode only, verify the release is running from `main`, the
@@ -121,8 +146,23 @@ does not perform git, npm, or GitHub release side effects.
 Publish mode performs external side effects only after tests, linting, artifact
 validation, compatibility consumer checks, and publish preflights pass. It never
 pushes to `main`; it only creates the release tag. The GitHub workflow only runs
-publish from `main` and targets the `npm-release` environment so repository
-environment protection rules can require approval before publishing.
+publish from `main`.
+
+`release-and-publish.yml` first computes and validates a release plan outside
+the protected publishing environment. After the dry run passes, the publish job
+enters the `npm-release` environment for approval, recomputes the plan at the
+same commit, and verifies the validated and publish-time summaries match before
+creating tags, publishing to npm, or creating the GitHub Release.
+
+The validation job summary includes the future GitHub Release notes generated
+from the same release plan. The protected `npm-release` environment links back
+to the workflow run so approvers can review the computed version, tag, dist-tag,
+and notes before approving the publish job.
+
+`promote-stable` refuses to publish if package-impacting commits landed after
+the latest prerelease tag. Tooling-only commits and configured package
+documentation paths can land after the prerelease, but package code or manifest
+changes require another prerelease before a stable promotion.
 
 The workflow is rerunnable. If the release tag already exists at `HEAD`, the
 pipeline reuses it. If the npm version already exists and the expected dist-tag

--- a/tools/release/cli.mjs
+++ b/tools/release/cli.mjs
@@ -1,11 +1,15 @@
+import { readFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 import {
+  assertReleasePlanSummaryMatches,
   createReleasePlan,
   printReleasePlan,
+  releaseBumps,
+  releaseIntents,
   summarizeReleasePlan,
 } from './src/plan.mjs';
 import { releaseModes, runReleasePipeline } from './src/pipeline.mjs';
@@ -18,15 +22,14 @@ export function runCli(args = hideBin(process.argv)) {
       'plan',
       'Print the computed release plan without changing files.',
       (command) =>
-        addVersionOption(command).option('json', {
+        addReleaseOptions(command).option('json', {
           describe: 'Print the release plan as JSON.',
           type: 'boolean',
           default: false,
         }),
       (argv) => {
         const plan = createReleasePlan({
-          prerelease: argv.prerelease,
-          versionSpecifier: argv.version,
+          ...toReleaseOptions(argv),
         });
 
         if (argv.json) {
@@ -35,6 +38,18 @@ export function runCli(args = hideBin(process.argv)) {
         }
 
         printReleasePlan(plan);
+      },
+    )
+    .command(
+      'notes',
+      'Print the planned GitHub Release notes without changing files.',
+      (command) => addReleaseOptions(command),
+      (argv) => {
+        const plan = createReleasePlan({
+          ...toReleaseOptions(argv),
+        });
+
+        process.stdout.write(plan.releaseNotes);
       },
     )
     .command(
@@ -50,9 +65,8 @@ export function runCli(args = hideBin(process.argv)) {
       (argv) =>
         runReleasePipeline({
           mode: argv.mode,
-          prerelease: argv.prerelease,
+          ...toReleaseOptions(argv),
           verbose: argv.verbose,
-          versionSpecifier: argv.version,
         }),
     )
     .command(
@@ -62,9 +76,8 @@ export function runCli(args = hideBin(process.argv)) {
       (argv) =>
         runReleasePipeline({
           mode: releaseModes.dryRun,
-          prerelease: argv.prerelease,
+          ...toReleaseOptions(argv),
           verbose: argv.verbose,
-          versionSpecifier: argv.version,
         }),
     )
     .command(
@@ -74,10 +87,32 @@ export function runCli(args = hideBin(process.argv)) {
       (argv) =>
         runReleasePipeline({
           mode: releaseModes.publish,
-          prerelease: argv.prerelease,
+          ...toReleaseOptions(argv),
           verbose: argv.verbose,
-          versionSpecifier: argv.version,
         }),
+    )
+    .command(
+      'verify-plan',
+      'Verify two release plan summaries describe the same release.',
+      (command) =>
+        command
+          .option('expected', {
+            demandOption: true,
+            describe: 'Path to the validated release plan JSON.',
+            type: 'string',
+          })
+          .option('actual', {
+            demandOption: true,
+            describe: 'Path to the recomputed release plan JSON.',
+            type: 'string',
+          }),
+      (argv) => {
+        assertReleasePlanSummaryMatches(
+          readPlanSummary(argv.expected),
+          readPlanSummary(argv.actual),
+        );
+        console.log('Release plan matches validated dry-run plan.');
+      },
     )
     .demandCommand(1, 'Specify a release command.')
     .recommendCommands()
@@ -87,26 +122,69 @@ export function runCli(args = hideBin(process.argv)) {
 }
 
 function addPipelineOptions(command) {
-  return addVersionOption(command).option('verbose', {
+  return addReleaseOptions(command).option('verbose', {
     describe: 'Print the release plan before executing.',
     type: 'boolean',
     default: false,
   });
 }
 
-function addVersionOption(command) {
+function addReleaseOptions(command) {
   return command
+    .option('intent', {
+      choices: Object.values(releaseIntents),
+      describe: 'Release intent to execute.',
+      type: 'string',
+    })
+    .option('bump', {
+      choices: Object.values(releaseBumps),
+      describe:
+        'Version bump for stable or prerelease intents. Defaults to auto.',
+      type: 'string',
+    })
+    .option('allow-major-without-prerelease', {
+      describe:
+        'Allow a stable major release without first publishing a prerelease train.',
+      type: 'boolean',
+      default: false,
+    })
+    .option('manual-version', {
+      describe:
+        'Exact semver version to publish when using the manual release intent.',
+      type: 'string',
+    })
+    .option('manual-reason', {
+      describe:
+        'Reason for using the manual release intent. Required with manual releases.',
+      type: 'string',
+    })
     .option('version', {
       describe:
-        'Explicit semver version or semver increment to release, such as 19.3.0, patch, minor, or major.',
+        'Legacy explicit semver version or increment, such as 19.3.0, patch, minor, or major.',
       type: 'string',
     })
     .option('prerelease', {
       default: false,
       describe:
-        'Infer or coerce the planned version to a next prerelease, such as 19.3.0-next.0.',
+        'Legacy flag to infer or coerce the planned version to a next prerelease.',
       type: 'boolean',
     });
+}
+
+function toReleaseOptions(argv) {
+  return {
+    allowMajorWithoutPrerelease: argv.allowMajorWithoutPrerelease,
+    bump: argv.bump,
+    manualReason: argv.manualReason,
+    manualVersion: argv.manualVersion,
+    prerelease: argv.prerelease,
+    releaseIntent: argv.intent,
+    versionSpecifier: argv.version,
+  };
+}
+
+function readPlanSummary(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
 }
 
 if (

--- a/tools/release/cli.mjs
+++ b/tools/release/cli.mjs
@@ -157,17 +157,6 @@ function addReleaseOptions(command) {
       describe:
         'Reason for using the manual release intent. Required with manual releases.',
       type: 'string',
-    })
-    .option('version', {
-      describe:
-        'Legacy explicit semver version or increment, such as 19.3.0, patch, minor, or major.',
-      type: 'string',
-    })
-    .option('prerelease', {
-      default: false,
-      describe:
-        'Legacy flag to infer or coerce the planned version to a next prerelease.',
-      type: 'boolean',
     });
 }
 
@@ -177,9 +166,7 @@ function toReleaseOptions(argv) {
     bump: argv.bump,
     manualReason: argv.manualReason,
     manualVersion: argv.manualVersion,
-    prerelease: argv.prerelease,
     releaseIntent: argv.intent,
-    versionSpecifier: argv.version,
   };
 }
 

--- a/tools/release/package.json
+++ b/tools/release/package.json
@@ -6,8 +6,10 @@
   "scripts": {
     "release": "node cli.mjs run",
     "release:dry-run": "node cli.mjs dry-run",
+    "release:notes": "node cli.mjs notes",
     "release:plan": "node cli.mjs plan",
     "release:publish": "node cli.mjs publish",
+    "release:verify-plan": "node cli.mjs verify-plan",
     "test": "node --test src/*.test.mjs"
   },
   "dependencies": {

--- a/tools/release/src/config.mjs
+++ b/tools/release/src/config.mjs
@@ -27,6 +27,10 @@ export const releasePackages = [
     releaseScopes: ['sanity'],
     releaseTagPrefix,
     root: 'packages/sanity',
+    stablePromotionIgnoredPaths: [
+      'packages/sanity/*.md',
+      'packages/sanity/**/*.md',
+    ],
   },
 ];
 export const defaultReleasePackage = releasePackages[0];

--- a/tools/release/src/pipeline.mjs
+++ b/tools/release/src/pipeline.mjs
@@ -75,9 +75,7 @@ export function runReleasePipeline(options = {}) {
     manualVersion: options.manualVersion,
     now: options.now,
     paths: options.paths,
-    prerelease: options.prerelease,
     releaseIntent: options.releaseIntent,
-    versionSpecifier: options.versionSpecifier,
   });
   if (options.verbose || mode === releaseModes.dryRun) {
     printReleasePlan(plan);

--- a/tools/release/src/pipeline.mjs
+++ b/tools/release/src/pipeline.mjs
@@ -68,10 +68,15 @@ export function runReleasePipeline(options = {}) {
   const commandRun = options.run ?? defaultRun;
   const commandCapture = options.capture ?? defaultCapture;
   const plan = createReleasePlan({
+    allowMajorWithoutPrerelease: options.allowMajorWithoutPrerelease,
+    bump: options.bump,
     capture: commandCapture,
+    manualReason: options.manualReason,
+    manualVersion: options.manualVersion,
     now: options.now,
     paths: options.paths,
     prerelease: options.prerelease,
+    releaseIntent: options.releaseIntent,
     versionSpecifier: options.versionSpecifier,
   });
   if (options.verbose || mode === releaseModes.dryRun) {

--- a/tools/release/src/pipeline.test.mjs
+++ b/tools/release/src/pipeline.test.mjs
@@ -38,8 +38,9 @@ test('dry-run validates the planned artifact version without mutating release fi
       mode: releaseModes.dryRun,
       now: new Date('2026-06-08T00:00:00.000Z'),
       paths: fixture.paths,
+      bump: releaseBumps.minor,
+      releaseIntent: releaseIntents.stable,
       run: harness.run,
-      versionSpecifier: 'minor',
     });
 
     assert.equal(result.published, false);
@@ -75,8 +76,9 @@ test('publish mode pushes the release tag before publishing to npm', () => {
       mode: releaseModes.publish,
       now: new Date('2026-06-08T00:00:00.000Z'),
       paths: fixture.paths,
+      bump: releaseBumps.patch,
+      releaseIntent: releaseIntents.stable,
       run: harness.run,
-      versionSpecifier: 'patch',
     });
 
     assert.equal(result.published, true);
@@ -195,8 +197,9 @@ test('publish mode resumes when tag, npm version, and GitHub release already exi
       mode: releaseModes.publish,
       now: new Date('2026-06-08T00:00:00.000Z'),
       paths: fixture.paths,
+      bump: releaseBumps.patch,
+      releaseIntent: releaseIntents.stable,
       run: harness.run,
-      versionSpecifier: 'patch',
     });
 
     assert.equal(result.published, true);
@@ -241,8 +244,9 @@ test('artifact version mismatch fails before publish side effects', () => {
           mode: releaseModes.publish,
           now: new Date('2026-06-08T00:00:00.000Z'),
           paths: fixture.paths,
+          bump: releaseBumps.patch,
+          releaseIntent: releaseIntents.stable,
           run: harness.run,
-          versionSpecifier: 'patch',
         }),
       /does not match planned release version 1\.0\.1/,
     );

--- a/tools/release/src/pipeline.test.mjs
+++ b/tools/release/src/pipeline.test.mjs
@@ -9,6 +9,7 @@ import {
   releaseModes,
   runReleasePipeline,
 } from './pipeline.mjs';
+import { releaseBumps, releaseIntents } from './plan.mjs';
 
 const trustedPublishingEnv = {
   ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'github-oidc-token',
@@ -130,7 +131,8 @@ test('publish mode tags npm and GitHub prereleases', () => {
       mode: releaseModes.publish,
       now: new Date('2026-06-08T00:00:00.000Z'),
       paths: fixture.paths,
-      prerelease: true,
+      bump: releaseBumps.auto,
+      releaseIntent: releaseIntents.prerelease,
       run: harness.run,
     });
 

--- a/tools/release/src/plan.mjs
+++ b/tools/release/src/plan.mjs
@@ -298,9 +298,11 @@ function resolveReleaseRequest({
 }
 
 function assertSupportedReleaseOptions(options) {
-  const unsupportedOptions = ['intent', 'prerelease', 'versionSpecifier'].filter(
-    (option) => Object.hasOwn(options, option),
-  );
+  const unsupportedOptions = [
+    'intent',
+    'prerelease',
+    'versionSpecifier',
+  ].filter((option) => Object.hasOwn(options, option));
 
   if (unsupportedOptions.length === 0) {
     return;

--- a/tools/release/src/plan.mjs
+++ b/tools/release/src/plan.mjs
@@ -16,6 +16,36 @@ const stableNpmDistTag = 'latest';
 const missingJsonFile = Symbol('missingJsonFile');
 const invalidJsonFile = Symbol('invalidJsonFile');
 
+export const releaseIntents = {
+  manual: 'manual',
+  prerelease: 'prerelease',
+  promoteStable: 'promote-stable',
+  stable: 'stable',
+};
+
+export const releaseBumps = {
+  auto: 'auto',
+  major: 'major',
+  minor: 'minor',
+  patch: 'patch',
+};
+
+export const comparableReleasePlanSummaryFields = [
+  'commitCount',
+  'currentVersion',
+  'headSha',
+  'latestTag',
+  'nextVersion',
+  'npmDistTag',
+  'packageName',
+  'prerelease',
+  'releaseBump',
+  'releaseIntent',
+  'releaseNotesBaseTag',
+  'releaseNotesCommitCount',
+  'releaseTag',
+];
+
 export function createReleasePlan(options = {}) {
   const releasePackage = options.releasePackage ?? defaultReleasePackage;
   const paths = resolveReleasePaths(options.paths, releasePackage);
@@ -40,15 +70,26 @@ export function createReleasePlan(options = {}) {
   const latestTag = releaseBaseTag?.tag ?? null;
   const allCommits = getCommitsSince(latestTag, { capture: commandCapture });
   const commits = filterReleaseCommits(allCommits, releasePackage);
-  const requestedNextVersion = resolveNextVersion(currentVersion, commits, {
-    prerelease: options.prerelease,
-    versionSpecifier: options.versionSpecifier,
+  const releaseRequest = resolveReleaseRequest({
+    commits,
+    currentVersion,
+    headReleaseTag,
+    latestReleaseTag,
+    options,
+    releaseBaseTag,
+    releasePackage,
   });
+  const requestedNextVersion = releaseRequest.nextVersion;
   const nextVersion = headReleaseTag?.version ?? requestedNextVersion;
 
-  if (!nextVersion) {
+  if (
+    headReleaseTag &&
+    releaseRequest.expectedPrerelease !== undefined &&
+    Boolean(semver.prerelease(headReleaseTag.version)) !==
+      releaseRequest.expectedPrerelease
+  ) {
     throw new Error(
-      `No release version could be determined for ${releasePackage.name}. Pass --version or add a package-relevant conventional commit with feat, fix, perf, refactor, or a breaking change.`,
+      `HEAD is already tagged for ${headReleaseTag.tag}; refusing to plan ${releaseRequest.releaseIntent}.`,
     );
   }
 
@@ -59,6 +100,12 @@ export function createReleasePlan(options = {}) {
   ) {
     throw new Error(
       `HEAD is already tagged for ${headReleaseTag.tag}; refusing to plan ${requestedNextVersion}.`,
+    );
+  }
+
+  if (!nextVersion) {
+    throw new Error(
+      `No release version could be determined for ${releasePackage.name}. Pass an explicit release intent or add a package-relevant conventional commit with feat, fix, perf, refactor, or a breaking change.`,
     );
   }
 
@@ -94,6 +141,7 @@ export function createReleasePlan(options = {}) {
     currentVersion,
     existingReleaseTag: Boolean(headReleaseTag),
     generatedAt: generatedAt.toISOString(),
+    headSha: getHeadSha({ capture: commandCapture }),
     latestTag,
     nextVersion,
     npmDistTag: isPrerelease ? prereleaseNpmDistTag : stableNpmDistTag,
@@ -102,6 +150,8 @@ export function createReleasePlan(options = {}) {
     releasePackage,
     paths,
     prerelease: isPrerelease,
+    releaseBump: releaseRequest.releaseBump,
+    releaseIntent: releaseRequest.releaseIntent,
     releaseNotes,
     releaseNotesBaseTag,
     releaseNotesCommits,
@@ -124,21 +174,45 @@ export function summarizeReleasePlan(plan) {
     currentVersion: plan.currentVersion,
     existingReleaseTag: plan.existingReleaseTag,
     generatedAt: plan.generatedAt,
+    headSha: plan.headSha,
     latestTag: plan.latestTag,
     nextVersion: plan.nextVersion,
     npmDistTag: plan.npmDistTag,
     packageName: plan.packageName,
     prerelease: plan.prerelease,
+    releaseBump: plan.releaseBump,
+    releaseIntent: plan.releaseIntent,
     releaseNotesBaseTag: plan.releaseNotesBaseTag,
     releaseNotesCommitCount: plan.releaseNotesCommits.length,
     releaseTag: plan.releaseTag,
   };
 }
 
+export function assertReleasePlanSummaryMatches(expected, actual) {
+  const mismatches = comparableReleasePlanSummaryFields.filter(
+    (field) => expected[field] !== actual[field],
+  );
+
+  if (mismatches.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    `Release plan changed after validation: ${mismatches
+      .map(
+        (field) =>
+          `${field} expected ${formatPlanValue(expected[field])}, found ${formatPlanValue(actual[field])}`,
+      )
+      .join('; ')}.`,
+  );
+}
+
 export function printReleasePlan(plan) {
   const summary = summarizeReleasePlan(plan);
 
   console.log(`Package: ${summary.packageName}`);
+  console.log(`Release intent: ${summary.releaseIntent}`);
+  console.log(`Release bump: ${summary.releaseBump}`);
   console.log(`Current version: ${summary.currentVersion}`);
   console.log(`Latest tag: ${summary.latestTag ?? 'none'}`);
   console.log(`Next version: ${summary.nextVersion}`);
@@ -157,6 +231,139 @@ function resolveReleasePaths(paths = {}, releasePackage) {
   };
 }
 
+function resolveReleaseRequest({
+  commits,
+  currentVersion,
+  headReleaseTag,
+  latestReleaseTag,
+  options,
+  releaseBaseTag,
+  releasePackage,
+}) {
+  if (hasMixedReleaseOptions(options)) {
+    throw new Error(
+      'Use either release intent options or legacy --version/--prerelease options, not both.',
+    );
+  }
+
+  if (hasLegacyReleaseOptions(options)) {
+    const nextVersion = resolveLegacyNextVersion(currentVersion, commits, {
+      prerelease: options.prerelease,
+      versionSpecifier: options.versionSpecifier,
+    });
+
+    return {
+      expectedPrerelease: undefined,
+      nextVersion,
+      releaseBump: options.versionSpecifier ?? releaseBumps.auto,
+      releaseIntent: options.prerelease
+        ? releaseIntents.prerelease
+        : releaseIntents.stable,
+    };
+  }
+
+  const releaseIntent = normalizeReleaseIntent(
+    options.releaseIntent ?? options.intent ?? releaseIntents.stable,
+  );
+  const releaseBump = normalizeReleaseBump(options.bump ?? releaseBumps.auto);
+
+  switch (releaseIntent) {
+    case releaseIntents.prerelease:
+      return {
+        expectedPrerelease: true,
+        nextVersion: resolvePrereleaseNextVersion(currentVersion, commits, {
+          bump: releaseBump,
+        }),
+        releaseBump,
+        releaseIntent,
+      };
+
+    case releaseIntents.promoteStable:
+      assertPromotableStableRelease({
+        commits,
+        headReleaseTag,
+        latestReleaseTag,
+        releaseBaseTag,
+        releasePackage,
+      });
+
+      return {
+        expectedPrerelease: false,
+        nextVersion: removePrerelease(
+          resolvePromotedPrereleaseTag({
+            headReleaseTag,
+            latestReleaseTag,
+            releaseBaseTag,
+          }).version,
+        ),
+        releaseBump: releaseBumps.auto,
+        releaseIntent,
+      };
+
+    case releaseIntents.manual:
+      return {
+        expectedPrerelease: undefined,
+        nextVersion: resolveManualVersion(options),
+        releaseBump: 'manual',
+        releaseIntent,
+      };
+
+    case releaseIntents.stable:
+      return {
+        expectedPrerelease: false,
+        nextVersion: resolveStableNextVersion(currentVersion, commits, {
+          allowMajorWithoutPrerelease: options.allowMajorWithoutPrerelease,
+          bump: releaseBump,
+          latestReleaseTag,
+        }),
+        releaseBump,
+        releaseIntent,
+      };
+
+    default:
+      throw new Error(`Unknown release intent: ${releaseIntent}`);
+  }
+}
+
+function hasLegacyReleaseOptions(options) {
+  return Boolean(options.versionSpecifier || options.prerelease);
+}
+
+function hasIntentReleaseOptions(options) {
+  return Boolean(
+    options.releaseIntent ||
+      options.intent ||
+      options.bump ||
+      options.manualVersion ||
+      options.manualReason ||
+      options.allowMajorWithoutPrerelease,
+  );
+}
+
+function hasMixedReleaseOptions(options) {
+  return hasLegacyReleaseOptions(options) && hasIntentReleaseOptions(options);
+}
+
+function normalizeReleaseIntent(intent) {
+  if (Object.values(releaseIntents).includes(intent)) {
+    return intent;
+  }
+
+  throw new Error(
+    `Unknown release intent: ${intent}. Expected one of ${Object.values(releaseIntents).join(', ')}.`,
+  );
+}
+
+function normalizeReleaseBump(bump) {
+  if (Object.values(releaseBumps).includes(bump)) {
+    return bump;
+  }
+
+  throw new Error(
+    `Unknown release bump: ${bump}. Expected one of ${Object.values(releaseBumps).join(', ')}.`,
+  );
+}
+
 function resolveNextVersion(currentVersion, commits, options = {}) {
   return options.versionSpecifier
     ? resolveVersionSpecifier(currentVersion, options.versionSpecifier, {
@@ -165,6 +372,177 @@ function resolveNextVersion(currentVersion, commits, options = {}) {
     : inferVersionFromCommits(currentVersion, commits, {
         prerelease: options.prerelease,
       });
+}
+
+function resolveLegacyNextVersion(currentVersion, commits, options = {}) {
+  return resolveNextVersion(currentVersion, commits, options);
+}
+
+function resolveStableNextVersion(currentVersion, commits, options = {}) {
+  const latestReleaseTag = options.latestReleaseTag;
+
+  if (latestReleaseTag && semver.prerelease(latestReleaseTag.version)) {
+    throw new Error(
+      `Latest release tag ${latestReleaseTag.tag} is a prerelease; use release intent ${releaseIntents.promoteStable} to publish it as stable.`,
+    );
+  }
+
+  const nextVersion = resolveBumpedStableVersion(currentVersion, commits, {
+    bump: options.bump,
+  });
+
+  if (
+    nextVersion &&
+    isMajorStableRelease(currentVersion, nextVersion) &&
+    !options.allowMajorWithoutPrerelease
+  ) {
+    throw new Error(
+      `Refusing to publish major stable release ${nextVersion} without a prerelease train. Use release intent ${releaseIntents.prerelease} with bump ${releaseBumps.major}, or pass --allow-major-without-prerelease.`,
+    );
+  }
+
+  return nextVersion;
+}
+
+function resolveBumpedStableVersion(currentVersion, commits, { bump }) {
+  if (bump === releaseBumps.auto) {
+    const releaseType = inferReleaseTypeFromCommits(commits);
+
+    return releaseType ? semver.inc(currentVersion, releaseType) : null;
+  }
+
+  return semver.inc(currentVersion, bump);
+}
+
+function resolvePrereleaseNextVersion(currentVersion, commits, { bump }) {
+  const releaseType =
+    bump === releaseBumps.auto ? inferReleaseTypeFromCommits(commits) : bump;
+
+  return releaseType
+    ? inferPrereleaseVersion(currentVersion, releaseType)
+    : null;
+}
+
+function resolveManualVersion(options) {
+  const manualVersion = options.manualVersion?.trim();
+  const manualReason = options.manualReason?.trim();
+
+  if (!manualVersion || !semver.valid(manualVersion)) {
+    throw new Error(
+      `Release intent ${releaseIntents.manual} requires --manual-version with an exact semver version.`,
+    );
+  }
+
+  if (!manualReason) {
+    throw new Error(
+      `Release intent ${releaseIntents.manual} requires --manual-reason.`,
+    );
+  }
+
+  return manualVersion;
+}
+
+function assertPromotableStableRelease({
+  commits,
+  headReleaseTag,
+  latestReleaseTag,
+  releaseBaseTag,
+  releasePackage,
+}) {
+  const prereleaseTag = resolvePromotedPrereleaseTag({
+    headReleaseTag,
+    latestReleaseTag,
+    releaseBaseTag,
+  });
+
+  if (!prereleaseTag) {
+    throw new Error(
+      `Release intent ${releaseIntents.promoteStable} requires the latest release tag to be a prerelease.`,
+    );
+  }
+
+  const blockingCommits = getStablePromotionBlockingCommits(
+    commits,
+    releasePackage,
+  );
+
+  if (blockingCommits.length > 0) {
+    throw new Error(
+      `Refusing to promote ${prereleaseTag.tag} because ${blockingCommits.length} package-impacting commit(s) landed after that prerelease. Publish another prerelease first.`,
+    );
+  }
+}
+
+function getStablePromotionBlockingCommits(commits, releasePackage) {
+  return commits.filter((commit) =>
+    hasStablePromotionBlockingFiles(commit, releasePackage),
+  );
+}
+
+function hasStablePromotionBlockingFiles(commit, releasePackage) {
+  const releaseFiles = getReleaseFiles(commit, releasePackage);
+
+  if (releaseFiles.length === 0) {
+    return true;
+  }
+
+  return releaseFiles.some(
+    (file) => !matchesStablePromotionIgnoredPath(file, releasePackage),
+  );
+}
+
+function matchesStablePromotionIgnoredPath(file, releasePackage) {
+  const ignoredPaths = releasePackage.stablePromotionIgnoredPaths ?? [];
+
+  return ignoredPaths.some((pattern) => matchesPathPattern(file, pattern));
+}
+
+function resolvePromotedPrereleaseTag({
+  headReleaseTag,
+  latestReleaseTag,
+  releaseBaseTag,
+}) {
+  if (headReleaseTag && !isPrereleaseVersion(headReleaseTag.version)) {
+    return isPrereleaseVersion(releaseBaseTag?.version) ? releaseBaseTag : null;
+  }
+
+  return isPrereleaseVersion(latestReleaseTag?.version)
+    ? latestReleaseTag
+    : null;
+}
+
+function removePrerelease(version) {
+  const parsedVersion = semver.parse(version);
+
+  if (!parsedVersion) {
+    throw new Error(`Invalid prerelease version: ${version}`);
+  }
+
+  return `${parsedVersion.major}.${parsedVersion.minor}.${parsedVersion.patch}`;
+}
+
+function isMajorStableRelease(currentVersion, nextVersion) {
+  return (
+    currentVersion !== initialReleaseVersion &&
+    !semver.prerelease(nextVersion) &&
+    semver.major(nextVersion) > semver.major(currentVersion)
+  );
+}
+
+function isPrereleaseVersion(version) {
+  return Boolean(version && semver.prerelease(version));
+}
+
+function getHeadSha({ capture }) {
+  try {
+    return capture('git', ['rev-parse', 'HEAD']).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function formatPlanValue(value) {
+  return value === null || value === undefined ? 'none' : JSON.stringify(value);
 }
 
 function getRepositoryUrl(repository) {

--- a/tools/release/src/plan.mjs
+++ b/tools/release/src/plan.mjs
@@ -47,6 +47,8 @@ export const comparableReleasePlanSummaryFields = [
 ];
 
 export function createReleasePlan(options = {}) {
+  assertSupportedReleaseOptions(options);
+
   const releasePackage = options.releasePackage ?? defaultReleasePackage;
   const paths = resolveReleasePaths(options.paths, releasePackage);
   const commandCapture = options.capture ?? defaultCapture;
@@ -160,14 +162,6 @@ export function createReleasePlan(options = {}) {
   };
 }
 
-export function resolveReleaseSpecifier(
-  currentVersion,
-  specifier,
-  options = {},
-) {
-  return resolveVersionSpecifier(currentVersion, specifier, options);
-}
-
 export function summarizeReleasePlan(plan) {
   return {
     commitCount: plan.commits.length,
@@ -240,30 +234,8 @@ function resolveReleaseRequest({
   releaseBaseTag,
   releasePackage,
 }) {
-  if (hasMixedReleaseOptions(options)) {
-    throw new Error(
-      'Use either release intent options or legacy --version/--prerelease options, not both.',
-    );
-  }
-
-  if (hasLegacyReleaseOptions(options)) {
-    const nextVersion = resolveLegacyNextVersion(currentVersion, commits, {
-      prerelease: options.prerelease,
-      versionSpecifier: options.versionSpecifier,
-    });
-
-    return {
-      expectedPrerelease: undefined,
-      nextVersion,
-      releaseBump: options.versionSpecifier ?? releaseBumps.auto,
-      releaseIntent: options.prerelease
-        ? releaseIntents.prerelease
-        : releaseIntents.stable,
-    };
-  }
-
   const releaseIntent = normalizeReleaseIntent(
-    options.releaseIntent ?? options.intent ?? releaseIntents.stable,
+    options.releaseIntent ?? releaseIntents.stable,
   );
   const releaseBump = normalizeReleaseBump(options.bump ?? releaseBumps.auto);
 
@@ -325,23 +297,18 @@ function resolveReleaseRequest({
   }
 }
 
-function hasLegacyReleaseOptions(options) {
-  return Boolean(options.versionSpecifier || options.prerelease);
-}
-
-function hasIntentReleaseOptions(options) {
-  return Boolean(
-    options.releaseIntent ||
-      options.intent ||
-      options.bump ||
-      options.manualVersion ||
-      options.manualReason ||
-      options.allowMajorWithoutPrerelease,
+function assertSupportedReleaseOptions(options) {
+  const unsupportedOptions = ['intent', 'prerelease', 'versionSpecifier'].filter(
+    (option) => Object.hasOwn(options, option),
   );
-}
 
-function hasMixedReleaseOptions(options) {
-  return hasLegacyReleaseOptions(options) && hasIntentReleaseOptions(options);
+  if (unsupportedOptions.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    `Unsupported release option(s): ${unsupportedOptions.join(', ')}. Use releaseIntent with bump, or releaseIntent manual with manualVersion and manualReason.`,
+  );
 }
 
 function normalizeReleaseIntent(intent) {
@@ -362,20 +329,6 @@ function normalizeReleaseBump(bump) {
   throw new Error(
     `Unknown release bump: ${bump}. Expected one of ${Object.values(releaseBumps).join(', ')}.`,
   );
-}
-
-function resolveNextVersion(currentVersion, commits, options = {}) {
-  return options.versionSpecifier
-    ? resolveVersionSpecifier(currentVersion, options.versionSpecifier, {
-        prerelease: options.prerelease,
-      })
-    : inferVersionFromCommits(currentVersion, commits, {
-        prerelease: options.prerelease,
-      });
-}
-
-function resolveLegacyNextVersion(currentVersion, commits, options = {}) {
-  return resolveNextVersion(currentVersion, commits, options);
 }
 
 function resolveStableNextVersion(currentVersion, commits, options = {}) {
@@ -553,42 +506,6 @@ function getRepositoryUrl(repository) {
   return repository?.url;
 }
 
-function resolveVersionSpecifier(currentVersion, specifier, options = {}) {
-  const trimmedSpecifier = specifier.trim();
-
-  if (semver.valid(trimmedSpecifier)) {
-    if (options.prerelease && !semver.prerelease(trimmedSpecifier)) {
-      return appendPrereleaseIdentifier(trimmedSpecifier);
-    }
-
-    return trimmedSpecifier;
-  }
-
-  if (options.prerelease) {
-    const prereleaseIncrement = toPrereleaseIncrement(trimmedSpecifier);
-
-    if (prereleaseIncrement) {
-      return semver.inc(
-        currentVersion,
-        prereleaseIncrement,
-        prereleaseIdentifier,
-      );
-    }
-  }
-
-  return semver.inc(currentVersion, trimmedSpecifier);
-}
-
-function inferVersionFromCommits(currentVersion, commits, options = {}) {
-  const releaseType = inferReleaseTypeFromCommits(commits);
-
-  if (options.prerelease) {
-    return inferPrereleaseVersion(currentVersion, releaseType);
-  }
-
-  return releaseType ? semver.inc(currentVersion, releaseType) : null;
-}
-
 function inferReleaseTypeFromCommits(commits) {
   if (commits.some(isBreakingCommit)) {
     return 'major';
@@ -619,32 +536,6 @@ function inferPrereleaseVersion(currentVersion, releaseType) {
   }
 
   return semver.inc(currentVersion, `pre${releaseType}`, prereleaseIdentifier);
-}
-
-function appendPrereleaseIdentifier(version) {
-  const prereleaseVersion = `${version}-${prereleaseIdentifier}.0`;
-
-  if (!semver.valid(prereleaseVersion)) {
-    throw new Error(`Could not create prerelease version from ${version}.`);
-  }
-
-  return prereleaseVersion;
-}
-
-function toPrereleaseIncrement(specifier) {
-  switch (specifier) {
-    case 'major':
-    case 'minor':
-    case 'patch':
-      return `pre${specifier}`;
-    case 'premajor':
-    case 'preminor':
-    case 'prepatch':
-    case 'prerelease':
-      return specifier;
-    default:
-      return null;
-  }
 }
 
 function resolveReleaseNotesBaseTag({

--- a/tools/release/src/plan.test.mjs
+++ b/tools/release/src/plan.test.mjs
@@ -5,7 +5,10 @@ import { join } from 'node:path';
 import { test } from 'node:test';
 
 import {
+  assertReleasePlanSummaryMatches,
   createReleasePlan,
+  releaseBumps,
+  releaseIntents,
   resolveReleaseSpecifier,
   summarizeReleasePlan,
 } from './plan.mjs';
@@ -57,6 +60,316 @@ test('release plan rejects explicit versions that do not move forward', () => {
   } finally {
     workspace.cleanup();
   }
+});
+
+test('stable release intent infers patch and minor releases from package commits', () => {
+  const workspace = createReleaseFixture();
+
+  try {
+    const patchPlan = createReleasePlan({
+      capture: createCapture({
+        gitLog:
+          'abc1234\x01fix(sanity): tighten release validation\x01\x01Alfonso\x02',
+      }),
+      now: new Date('2026-06-08T00:00:00.000Z'),
+      paths: workspace.paths,
+      releaseIntent: releaseIntents.stable,
+    });
+
+    assert.equal(patchPlan.nextVersion, '1.0.1');
+    assert.equal(patchPlan.releaseIntent, releaseIntents.stable);
+    assert.equal(patchPlan.releaseBump, releaseBumps.auto);
+
+    const minorPlan = createReleasePlan({
+      capture: createCapture({
+        gitLog:
+          'abc1234\x01feat(sanity): add release validation\x01\x01Alfonso\x02',
+      }),
+      now: new Date('2026-06-08T00:00:00.000Z'),
+      paths: workspace.paths,
+      releaseIntent: releaseIntents.stable,
+    });
+
+    assert.equal(minorPlan.nextVersion, '1.1.0');
+  } finally {
+    workspace.cleanup();
+  }
+});
+
+test('stable release intent requires confirmation for major releases without prereleases', () => {
+  const workspace = createReleaseFixture();
+
+  try {
+    assert.throws(
+      () =>
+        createReleasePlan({
+          capture: createCapture({
+            gitLog:
+              'abc1234\x01feat(sanity)!: add Angular 22 support\x01BREAKING CHANGE: Angular 19 is no longer supported.\x01Alfonso\x02',
+          }),
+          now: new Date('2026-06-08T00:00:00.000Z'),
+          paths: workspace.paths,
+          releaseIntent: releaseIntents.stable,
+        }),
+      /Refusing to publish major stable release 2\.0\.0 without a prerelease train/,
+    );
+
+    const plan = createReleasePlan({
+      allowMajorWithoutPrerelease: true,
+      capture: createCapture({
+        gitLog:
+          'abc1234\x01feat(sanity)!: add Angular 22 support\x01BREAKING CHANGE: Angular 19 is no longer supported.\x01Alfonso\x02',
+      }),
+      now: new Date('2026-06-08T00:00:00.000Z'),
+      paths: workspace.paths,
+      releaseIntent: releaseIntents.stable,
+    });
+
+    assert.equal(plan.nextVersion, '2.0.0');
+    assert.equal(plan.npmDistTag, 'latest');
+  } finally {
+    workspace.cleanup();
+  }
+});
+
+test('stable release intent refuses to guess when latest release is a prerelease', () => {
+  const workspace = createReleaseFixture();
+
+  try {
+    assert.throws(
+      () =>
+        createReleasePlan({
+          bump: releaseBumps.patch,
+          capture: createCapture({
+            gitLog: '',
+            releaseTags: ['sanity@2.0.0-next.0', 'sanity@1.0.0'],
+          }),
+          now: new Date('2026-06-08T00:00:00.000Z'),
+          paths: workspace.paths,
+          releaseIntent: releaseIntents.stable,
+        }),
+      /Latest release tag sanity@2\.0\.0-next\.0 is a prerelease/,
+    );
+  } finally {
+    workspace.cleanup();
+  }
+});
+
+test('prerelease intent supports explicit major release trains without typing a version', () => {
+  const workspace = createReleaseFixture();
+
+  try {
+    const plan = createReleasePlan({
+      bump: releaseBumps.major,
+      capture: createCapture({ gitLog: '' }),
+      now: new Date('2026-06-08T00:00:00.000Z'),
+      paths: workspace.paths,
+      releaseIntent: releaseIntents.prerelease,
+    });
+
+    assert.equal(plan.currentVersion, '1.0.0');
+    assert.equal(plan.nextVersion, '2.0.0-next.0');
+    assert.equal(plan.npmDistTag, 'next');
+    assert.equal(plan.prerelease, true);
+    assert.equal(plan.releaseTag, 'sanity@2.0.0-next.0');
+  } finally {
+    workspace.cleanup();
+  }
+});
+
+test('promote-stable intent derives stable version from latest prerelease train', () => {
+  const workspace = createReleaseFixture();
+
+  try {
+    const plan = createReleasePlan({
+      capture: createCapture({
+        gitLogs: {
+          'sanity@2.0.0-next.1..HEAD': '',
+          'sanity@1.0.0..HEAD': [
+            'abc1234\x01feat(sanity): add Angular 22 support\x01\x01Alfonso',
+            'def5678\x01fix(sanity): handle live preview initialization\x01\x01Blanca',
+          ].join('\x02'),
+        },
+        releaseTags: [
+          'sanity@2.0.0-next.1',
+          'sanity@2.0.0-next.0',
+          'sanity@1.0.0',
+        ],
+      }),
+      now: new Date('2026-06-08T00:00:00.000Z'),
+      paths: workspace.paths,
+      releaseIntent: releaseIntents.promoteStable,
+    });
+
+    assert.equal(plan.currentVersion, '2.0.0-next.1');
+    assert.equal(plan.nextVersion, '2.0.0');
+    assert.equal(plan.releaseIntent, releaseIntents.promoteStable);
+    assert.equal(plan.releaseBump, releaseBumps.auto);
+    assert.equal(plan.releaseNotesBaseTag, 'sanity@1.0.0');
+    assert.equal(plan.releaseNotesCommits.length, 2);
+  } finally {
+    workspace.cleanup();
+  }
+});
+
+test('promote-stable intent rejects package commits after the latest prerelease', () => {
+  const workspace = createReleaseFixture();
+
+  try {
+    assert.throws(
+      () =>
+        createReleasePlan({
+          capture: createCapture({
+            gitLog:
+              'abc1234\x01fix(sanity): change package after prerelease\x01\x01Alfonso\x02',
+            releaseTags: ['sanity@2.0.0-next.0', 'sanity@1.0.0'],
+          }),
+          now: new Date('2026-06-08T00:00:00.000Z'),
+          paths: workspace.paths,
+          releaseIntent: releaseIntents.promoteStable,
+        }),
+      /package-impacting commit\(s\) landed after that prerelease/,
+    );
+  } finally {
+    workspace.cleanup();
+  }
+});
+
+test('promote-stable intent allows package documentation commits after the latest prerelease', () => {
+  const workspace = createReleaseFixture();
+
+  try {
+    const plan = createReleasePlan({
+      capture: createCapture({
+        changedFiles: {
+          abc1234: ['packages/sanity/README.md'],
+        },
+        gitLogs: {
+          'sanity@2.0.0-next.0..HEAD':
+            'abc1234\x01docs(sanity): update Angular compatibility table\x01\x01Alfonso\x02',
+          'sanity@1.0.0..HEAD':
+            'def5678\x01feat(sanity): add Angular 22 support\x01\x01Alfonso\x02',
+        },
+        releaseTags: ['sanity@2.0.0-next.0', 'sanity@1.0.0'],
+      }),
+      now: new Date('2026-06-08T00:00:00.000Z'),
+      paths: workspace.paths,
+      releaseIntent: releaseIntents.promoteStable,
+    });
+
+    assert.equal(plan.nextVersion, '2.0.0');
+    assert.equal(plan.releaseNotesBaseTag, 'sanity@1.0.0');
+    assert.equal(plan.commits.length, 1);
+  } finally {
+    workspace.cleanup();
+  }
+});
+
+test('manual release intent requires an exact version and reason', () => {
+  const workspace = createReleaseFixture();
+
+  try {
+    assert.throws(
+      () =>
+        createReleasePlan({
+          capture: createCapture({ gitLog: '' }),
+          manualVersion: '1.1.0',
+          now: new Date('2026-06-08T00:00:00.000Z'),
+          paths: workspace.paths,
+          releaseIntent: releaseIntents.manual,
+        }),
+      /requires --manual-reason/,
+    );
+
+    const plan = createReleasePlan({
+      capture: createCapture({ gitLog: '' }),
+      manualReason: 'Recover from an external release-state mismatch.',
+      manualVersion: '1.1.0',
+      now: new Date('2026-06-08T00:00:00.000Z'),
+      paths: workspace.paths,
+      releaseIntent: releaseIntents.manual,
+    });
+
+    assert.equal(plan.nextVersion, '1.1.0');
+    assert.equal(plan.releaseIntent, releaseIntents.manual);
+    assert.equal(plan.releaseBump, 'manual');
+  } finally {
+    workspace.cleanup();
+  }
+});
+
+test('release plan summary comparison reports publish-time drift', () => {
+  assert.doesNotThrow(() =>
+    assertReleasePlanSummaryMatches(
+      {
+        commitCount: 1,
+        currentVersion: '1.0.0',
+        headSha: 'abc123',
+        latestTag: 'sanity@1.0.0',
+        nextVersion: '1.0.1',
+        npmDistTag: 'latest',
+        packageName: '@limitless-angular/sanity',
+        prerelease: false,
+        releaseBump: releaseBumps.auto,
+        releaseIntent: releaseIntents.stable,
+        releaseNotesBaseTag: 'sanity@1.0.0',
+        releaseNotesCommitCount: 1,
+        releaseTag: 'sanity@1.0.1',
+      },
+      {
+        commitCount: 1,
+        currentVersion: '1.0.0',
+        headSha: 'abc123',
+        latestTag: 'sanity@1.0.0',
+        nextVersion: '1.0.1',
+        npmDistTag: 'latest',
+        packageName: '@limitless-angular/sanity',
+        prerelease: false,
+        releaseBump: releaseBumps.auto,
+        releaseIntent: releaseIntents.stable,
+        releaseNotesBaseTag: 'sanity@1.0.0',
+        releaseNotesCommitCount: 1,
+        releaseTag: 'sanity@1.0.1',
+      },
+    ),
+  );
+
+  assert.throws(
+    () =>
+      assertReleasePlanSummaryMatches(
+        {
+          commitCount: 1,
+          currentVersion: '1.0.0',
+          headSha: 'abc123',
+          latestTag: 'sanity@1.0.0',
+          nextVersion: '1.0.1',
+          npmDistTag: 'latest',
+          packageName: '@limitless-angular/sanity',
+          prerelease: false,
+          releaseBump: releaseBumps.auto,
+          releaseIntent: releaseIntents.stable,
+          releaseNotesBaseTag: 'sanity@1.0.0',
+          releaseNotesCommitCount: 1,
+          releaseTag: 'sanity@1.0.1',
+        },
+        {
+          commitCount: 1,
+          currentVersion: '1.0.0',
+          headSha: 'def456',
+          latestTag: 'sanity@1.0.0',
+          nextVersion: '1.1.0',
+          npmDistTag: 'latest',
+          packageName: '@limitless-angular/sanity',
+          prerelease: false,
+          releaseBump: releaseBumps.auto,
+          releaseIntent: releaseIntents.stable,
+          releaseNotesBaseTag: 'sanity@1.0.0',
+          releaseNotesCommitCount: 1,
+          releaseTag: 'sanity@1.1.0',
+        },
+      ),
+    /nextVersion expected "1\.0\.1", found "1\.1\.0"/,
+  );
 });
 
 test('release plan infers the next version from conventional commits', () => {
@@ -305,6 +618,7 @@ test('release notes include breaking change descriptions', () => {
 
   try {
     const plan = createReleasePlan({
+      allowMajorWithoutPrerelease: true,
       capture: createCapture({
         gitLog: [
           'abc1234',
@@ -328,7 +642,7 @@ test('release notes include breaking change descriptions', () => {
     assert.match(plan.releaseNotes, /- add Angular 20 support/);
     assert.match(
       plan.releaseNotes,
-      /  - Angular 17 is no longer supported\. Consumers must use Angular 18 or newer\./,
+      / {2}- Angular 17 is no longer supported\. Consumers must use Angular 18 or newer\./,
     );
     assert.doesNotMatch(plan.releaseNotes, /autofix/);
     assert.doesNotMatch(plan.releaseNotes, /Refs: #123/);

--- a/tools/release/src/plan.test.mjs
+++ b/tools/release/src/plan.test.mjs
@@ -9,31 +9,10 @@ import {
   createReleasePlan,
   releaseBumps,
   releaseIntents,
-  resolveReleaseSpecifier,
   summarizeReleasePlan,
 } from './plan.mjs';
 
-test('release specifier accepts semver increments and explicit versions', () => {
-  assert.equal(resolveReleaseSpecifier('1.2.3', 'patch'), '1.2.4');
-  assert.equal(resolveReleaseSpecifier('1.2.3', 'minor'), '1.3.0');
-  assert.equal(resolveReleaseSpecifier('1.2.3', '2.0.0'), '2.0.0');
-  assert.equal(
-    resolveReleaseSpecifier('1.2.3', 'minor', { prerelease: true }),
-    '1.3.0-next.0',
-  );
-  assert.equal(
-    resolveReleaseSpecifier('1.2.3', '2.0.0', { prerelease: true }),
-    '2.0.0-next.0',
-  );
-  assert.equal(
-    resolveReleaseSpecifier('1.2.3', '2.0.0-next.2', {
-      prerelease: true,
-    }),
-    '2.0.0-next.2',
-  );
-});
-
-test('release plan rejects explicit versions that do not move forward', () => {
+test('manual release intent rejects versions that do not move forward', () => {
   const workspace = createReleaseFixture();
 
   try {
@@ -41,9 +20,11 @@ test('release plan rejects explicit versions that do not move forward', () => {
       () =>
         createReleasePlan({
           capture: createCapture({ gitLog: '', releaseTags: ['sanity@1.2.3'] }),
+          manualReason: 'Recover from an external release-state mismatch.',
+          manualVersion: '1.2.2',
           now: new Date('2026-06-08T00:00:00.000Z'),
           paths: workspace.paths,
-          versionSpecifier: '1.2.2',
+          releaseIntent: releaseIntents.manual,
         }),
       /must be greater than the current version 1\.2\.3/,
     );
@@ -51,9 +32,11 @@ test('release plan rejects explicit versions that do not move forward', () => {
       () =>
         createReleasePlan({
           capture: createCapture({ gitLog: '', releaseTags: ['sanity@1.2.3'] }),
+          manualReason: 'Recover from an external release-state mismatch.',
+          manualVersion: '1.2.3',
           now: new Date('2026-06-08T00:00:00.000Z'),
           paths: workspace.paths,
-          versionSpecifier: '1.2.3',
+          releaseIntent: releaseIntents.manual,
         }),
       /must be greater than the current version 1\.2\.3/,
     );
@@ -298,6 +281,35 @@ test('manual release intent requires an exact version and reason', () => {
   }
 });
 
+test('release plan rejects removed option aliases', () => {
+  const workspace = createReleaseFixture();
+
+  try {
+    assert.throws(
+      () =>
+        createReleasePlan({
+          capture: createCapture({ gitLog: '' }),
+          now: new Date('2026-06-08T00:00:00.000Z'),
+          paths: workspace.paths,
+          versionSpecifier: '1.1.0',
+        }),
+      /Unsupported release option\(s\): versionSpecifier/,
+    );
+    assert.throws(
+      () =>
+        createReleasePlan({
+          capture: createCapture({ gitLog: '' }),
+          now: new Date('2026-06-08T00:00:00.000Z'),
+          paths: workspace.paths,
+          prerelease: true,
+        }),
+      /Unsupported release option\(s\): prerelease/,
+    );
+  } finally {
+    workspace.cleanup();
+  }
+});
+
 test('release plan summary comparison reports publish-time drift', () => {
   assert.doesNotThrow(() =>
     assertReleasePlanSummaryMatches(
@@ -442,7 +454,7 @@ test('release plan ignores tooling-only conventional commits', () => {
           }),
           now: new Date('2026-06-08T00:00:00.000Z'),
           paths: workspace.paths,
-          prerelease: true,
+          releaseIntent: releaseIntents.prerelease,
         }),
       /No release version could be determined for @limitless-angular\/sanity/,
     );
@@ -485,7 +497,7 @@ test('release plan ignores configured infrastructure scopes on source-only packa
           }),
           now: new Date('2026-06-08T00:00:00.000Z'),
           paths: workspace.paths,
-          prerelease: true,
+          releaseIntent: releaseIntents.prerelease,
         }),
       /No release version could be determined for @limitless-angular\/sanity/,
     );
@@ -651,7 +663,7 @@ test('release notes include breaking change descriptions', () => {
   }
 });
 
-test('explicit release versions bypass package relevance inference', () => {
+test('manual release intent bypasses package relevance inference', () => {
   const workspace = createReleaseFixture();
 
   try {
@@ -663,9 +675,11 @@ test('explicit release versions bypass package relevance inference', () => {
         gitLog:
           'abc1234\x01feat(release): publish from tags without source version churn\x01\x01Alfonso\x02',
       }),
+      manualReason: 'Recover from an external release-state mismatch.',
+      manualVersion: '1.1.0',
       now: new Date('2026-06-08T00:00:00.000Z'),
       paths: workspace.paths,
-      versionSpecifier: '1.1.0',
+      releaseIntent: releaseIntents.manual,
     });
 
     assert.equal(plan.nextVersion, '1.1.0');
@@ -687,7 +701,7 @@ test('prerelease plan infers next prerelease from conventional commits', () => {
       }),
       now: new Date('2026-06-08T00:00:00.000Z'),
       paths: workspace.paths,
-      prerelease: true,
+      releaseIntent: releaseIntents.prerelease,
     });
 
     assert.equal(plan.currentVersion, '1.0.0');
@@ -713,7 +727,7 @@ test('prerelease plan increments the current prerelease train', () => {
       }),
       now: new Date('2026-06-08T00:00:00.000Z'),
       paths: workspace.paths,
-      prerelease: true,
+      releaseIntent: releaseIntents.prerelease,
     });
 
     assert.equal(plan.currentVersion, '1.1.0-next.0');
@@ -749,7 +763,7 @@ test('stable release notes include the full prerelease train', () => {
       }),
       now: new Date('2026-06-08T00:00:00.000Z'),
       paths: workspace.paths,
-      versionSpecifier: '1.1.0',
+      releaseIntent: releaseIntents.promoteStable,
     });
 
     assert.equal(plan.currentVersion, '1.1.0-next.1');
@@ -813,7 +827,7 @@ test('release plan resumes an existing release tag on HEAD', () => {
       }),
       now: new Date('2026-06-08T00:00:00.000Z'),
       paths: workspace.paths,
-      prerelease: true,
+      releaseIntent: releaseIntents.prerelease,
     });
 
     assert.equal(plan.currentVersion, '1.0.0');


### PR DESCRIPTION
## PR Checklist

Closes # N/A

## What is the new behavior?

- Replaces loose release workflow version inputs with explicit release intents: stable, prerelease, promote-stable, and manual.
- Removes the old release option aliases from the release CLI/planner so maintainers use one model: intent plus bump, with manual releases requiring an exact version and reason.
- Keeps version math inside tools/release and makes publish recompute and verify the validated plan before touching tags, npm, or GitHub Releases.
- Adds release:notes so workflows can render the future GitHub Release notes from the same release plan.
- Shows planned version, tag, dist-tag, and future release notes in the validation job summary before npm-release approval; the protected environment links back to the workflow run.
- Guards stable major releases and stable prerelease promotion, while allowing configured package documentation updates after a prerelease.
- Hardens release workflow contract tests by parsing workflow YAML semantically instead of depending on fragile text snippets.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

No breaking change for package consumers. Maintainers will use release intent inputs instead of manually typing release versions in the GitHub workflows or passing release option aliases to the internal release CLI.

## Other information

Validation performed:

- `pnpm --filter=@limitless-angular/release-tools test`
- `./node_modules/.bin/eslint tools/release/cli.mjs tools/release/src/plan.mjs tools/release/src/pipeline.mjs tools/release/src/plan.test.mjs tools/release/src/pipeline.test.mjs`
- `pnpm turbo run test --filter=@limitless-angular/angular-compat`
- `pnpm --filter=@limitless-angular/release-tools run --silent release:notes --intent prerelease --bump major`
- `ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f); puts "parsed #{f}" }' .github/workflows/release-dry-run.yml .github/workflows/release-and-publish.yml`
- `git diff --check`
- PR #76 GitHub checks are passing on the latest head.

Architecture note: GitHub Actions remains orchestration and approval only; release intent, version derivation, release notes, and plan comparison stay inside tools/release.

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

N/A
