### PR TITLE
fix(sanity): remove lodash-es deep imports

### DIFF
--- a/packages/sanity/ng-package.json
+++ b/packages/sanity/ng-package.json
@@ -16,7 +16,6 @@
     "@sanity/visual-editing-csm",
     "@vercel/stega",
     "dequal",
-    "lodash-es",
     "xstate"
   ]
 }

--- a/packages/sanity/package.json
+++ b/packages/sanity/package.json
@@ -51,7 +51,6 @@
     "@sanity/visual-editing-csm": "^3.0.9",
     "@vercel/stega": "1.1.0",
     "dequal": "^2.0.3",
-    "lodash-es": "^4.17.21",
     "tslib": "^2.3.0",
     "xstate": "^5.19.2"
   },
@@ -67,7 +66,6 @@
     "@sanity/client": "^7.22.1",
     "@testing-library/angular": "^19.4.1",
     "@testing-library/dom": "^10.4.0",
-    "@types/lodash-es": "^4.17.12",
     "@types/node": "~22.19.20",
     "angular-eslint": "^22.0.0",
     "eslint": "^9.8.0",

--- a/packages/sanity/portabletext/src/services/block-handler.service.ts
+++ b/packages/sanity/portabletext/src/services/block-handler.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { PortableTextBlock } from '@portabletext/types';
-import { memoize } from 'lodash-es';
 
 import {
   MissingComponentHandler,
@@ -8,6 +7,7 @@ import {
   Serializable,
 } from '../types';
 import { serializeBlock } from '../utils';
+import { memoize } from '../utils/memoize';
 import { unknownBlockStyleWarning } from '../warnings';
 import { isPortableTextBlock } from '@portabletext/toolkit';
 

--- a/packages/sanity/portabletext/src/services/list-item-handler.service.ts
+++ b/packages/sanity/portabletext/src/services/list-item-handler.service.ts
@@ -4,7 +4,6 @@ import {
   PortableTextMarkDefinition,
   PortableTextSpan,
 } from '@portabletext/types';
-import { memoize } from 'lodash-es';
 
 import {
   MissingComponentHandler,
@@ -12,6 +11,7 @@ import {
   Serializable,
 } from '../types';
 import { serializeBlock } from '../utils';
+import { memoize } from '../utils/memoize';
 import { unknownListItemStyleWarning } from '../warnings';
 import { isPortableTextListItemBlock } from '@portabletext/toolkit';
 

--- a/packages/sanity/portabletext/src/utils/memoize.spec.ts
+++ b/packages/sanity/portabletext/src/utils/memoize.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { memoize } from './memoize';
+
+describe('memoize', () => {
+  it('returns the cached result for the same argument reference', () => {
+    const fn = vi.fn((value: { text: string }) => [value.text]);
+    const memoized = memoize(fn);
+    const value = { text: 'cached' };
+
+    const first = memoized(value);
+    const second = memoized(value);
+
+    expect(second).toBe(first);
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it('treats equal object values with different references as separate keys', () => {
+    const fn = vi.fn((value: { text: string }) => [value.text]);
+    const memoized = memoize(fn);
+
+    const first = memoized({ text: 'same value' });
+    const second = memoized({ text: 'same value' });
+
+    expect(second).not.toBe(first);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/sanity/portabletext/src/utils/memoize.ts
+++ b/packages/sanity/portabletext/src/utils/memoize.ts
@@ -1,0 +1,15 @@
+export function memoize<Arg, Result>(
+  fn: (arg: Arg) => Result,
+): (arg: Arg) => Result {
+  const cache = new Map<Arg, Result>();
+
+  return (arg) => {
+    if (cache.has(arg)) {
+      return cache.get(arg) as Result;
+    }
+
+    const result = fn(arg);
+    cache.set(arg, result);
+    return result;
+  };
+}

--- a/packages/sanity/preview-kit/src/live-preview.service.ts
+++ b/packages/sanity/preview-kit/src/live-preview.service.ts
@@ -9,7 +9,7 @@ import type {
   SanityClient,
   SyncTag,
 } from '@sanity/client';
-import isEqual from 'lodash-es/isEqual';
+import { dequal as isEqual } from 'dequal';
 import {
   EMPTY,
   Observable,

--- a/packages/sanity/preview-kit/src/live-query-provider/live-queries.service.spec.ts
+++ b/packages/sanity/preview-kit/src/live-query-provider/live-queries.service.spec.ts
@@ -1,5 +1,6 @@
 import { getQueryCacheKey } from './utils';
 import { LiveQueriesService } from './live-queries.service';
+import type { ContentSourceMap } from '@sanity/client';
 
 describe('LiveQueriesService', () => {
   it('tracks query subscriptions by query, params, and perspective', () => {
@@ -53,5 +54,41 @@ describe('LiveQueriesService', () => {
     expect(values).toEqual([{ title: 'Initial' }, { title: 'Live' }]);
 
     subscription.unsubscribe();
+  });
+
+  it('uses deep equality for source maps when deciding whether to update', () => {
+    const service = new LiveQueriesService();
+    const query = '*[_id == $id][0]';
+    const params = { id: 'post' };
+    const key = getQueryCacheKey(query, params, 'drafts');
+    const result = { title: 'Live' };
+    const sourceMap = {
+      documents: [{ _id: 'post', _type: 'post' }],
+      mappings: {
+        title: {
+          source: {
+            document: 0,
+            path: 0,
+            type: 'documentValue',
+          },
+          type: 'value',
+        },
+      },
+      paths: ['title'],
+    } satisfies ContentSourceMap;
+
+    expect(service.update(key, result, sourceMap, ['s1:post'])).toBe(true);
+    expect(
+      service.update(
+        key,
+        { title: 'Live' },
+        {
+          ...sourceMap,
+          documents: [{ _id: 'post', _type: 'post' }],
+          paths: ['title'],
+        },
+        ['s1:post'],
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/sanity/preview-kit/src/live-query-provider/live-queries.service.ts
+++ b/packages/sanity/preview-kit/src/live-query-provider/live-queries.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import type { ContentSourceMap, QueryParams, SyncTag } from '@sanity/client';
-import isEqual from 'lodash-es/isEqual';
+import { dequal as isEqual } from 'dequal';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { distinctUntilChanged, map } from 'rxjs/operators';
 

--- a/packages/sanity/preview-kit/src/perspective.service.ts
+++ b/packages/sanity/preview-kit/src/perspective.service.ts
@@ -7,7 +7,7 @@ import {
   type LoaderControllerMsg,
   type LoaderNodeMsg,
 } from '@sanity/presentation-comlink';
-import isEqual from 'lodash-es/isEqual';
+import { dequal as isEqual } from 'dequal';
 import { BehaviorSubject, combineLatest, type Observable } from 'rxjs';
 import { distinctUntilChanged, map } from 'rxjs/operators';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -472,9 +472,6 @@ importers:
       dequal:
         specifier: ^2.0.3
         version: 2.0.3
-      lodash-es:
-        specifier: ^4.17.21
-        version: 4.17.21
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
@@ -515,9 +512,6 @@ importers:
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.0
-      '@types/lodash-es':
-        specifier: ^4.17.12
-        version: 4.17.12
       '@types/node':
         specifier: ~22.19.20
         version: 22.19.20
@@ -4165,12 +4159,6 @@ packages:
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
 
-  '@types/lodash-es@4.17.12':
-    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
-
-  '@types/lodash@4.17.13':
-    resolution: {integrity: sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==}
-
   '@types/markdown-it@14.1.2':
     resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
 
@@ -6545,8 +6533,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash-es@4.17.21:
-    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+  locate-path@7.2.0:
+    resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
@@ -12960,12 +12949,6 @@ snapshots:
 
   '@types/linkify-it@5.0.0': {}
 
-  '@types/lodash-es@4.17.12':
-    dependencies:
-      '@types/lodash': 4.17.13
-
-  '@types/lodash@4.17.13': {}
-
   '@types/markdown-it@14.1.2':
     dependencies:
       '@types/linkify-it': 5.0.0
@@ -15559,7 +15542,10 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash-es@4.17.21: {}
+  locate-path@7.2.0:
+    dependencies:
+      p-locate: 6.0.0
+    optional: true
 
   lodash-es@4.18.1: {}
 

--- a/tools/angular-compat/pack.mjs
+++ b/tools/angular-compat/pack.mjs
@@ -52,7 +52,6 @@ export function packCompatibilityArtifact() {
       '@angular/compiler-cli': toolchain.compilerCliVersion,
       '@angular/core': toolchain.angularVersion,
       '@angular/router': toolchain.angularVersion,
-      '@types/lodash-es': packageJson.devDependencies['@types/lodash-es'],
       '@types/node': packageJson.devDependencies['@types/node'],
       'ng-packagr': toolchain.ngPackagrVersion,
       typescript: toolchain.typescriptVersion,


### PR DESCRIPTION
## PR Checklist

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes N/A

## What is the new behavior?

- Removes the direct `lodash-es` dependency from `@limitless-angular/sanity`.
- Replaces preview-kit `lodash-es/isEqual` deep imports with the existing `dequal` dependency, so the published FESM no longer ships the extensionless `lodash-es/isEqual` import that fails in some Vitest/Node-side consumer setups.
- Replaces portable text lodash `memoize` usage with a small local `memoize` helper that preserves the one-argument reference-cache behavior used by the services.
- Adds regression tests for memoization behavior and live query source-map deep equality.
- Updates Angular compatibility packaging so it no longer carries `@types/lodash-es`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This fixes a consumer-side Vitest/Node ESM resolution issue caused by the previous extensionless `lodash-es/isEqual` import in `@limitless-angular/sanity/preview-kit`.

Testing:

- `pnpm --filter @limitless-angular/sanity test -- portabletext/src/utils/memoize.spec.ts preview-kit/src/live-query-provider/live-queries.service.spec.ts`
- `pnpm --filter @limitless-angular/sanity build`
- `pnpm --filter @limitless-angular/sanity lint`

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

N/A