### PR TITLE
docs(sanity): describe Angular 22 as stable

### DIFF
--- a/packages/sanity/README.md
+++ b/packages/sanity/README.md
@@ -37,14 +37,8 @@ npm install --save @limitless-angular/sanity @sanity/client
 | 19.x    | 21.x, 20.x, 19.x            |
 | 18.x    | 20.x, 19.x, 18.x            |
 
-The current stable 21.x package line supports Angular 19, Angular 20, and
-Angular 21.
-
-Angular 22 support is available on the `next` prerelease line:
-
-```bash
-npm install @limitless-angular/sanity@next
-```
+The current stable 22.x package line supports Angular 20, Angular 21, and
+Angular 22.
 
 ## Quick Start
 


### PR DESCRIPTION
## PR Checklist

Updates the README compatibility copy after Angular 22 moved from prerelease availability to the stable package line. Mirrors the Angular 21 stable-docs change from de85d162e01227fc7995eaf645f36e774c68f698 for Angular 22.

Closes N/A

## What is the new behavior?

The package README now states that the current stable 22.x package line supports Angular 20, Angular 21, and Angular 22. It also removes the obsolete `@next` install instructions for Angular 22.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validation:

- `pnpm exec prettier --check packages/sanity/README.md`
- `git diff --check origin/main...HEAD`

No screenshots included because this is a README-only documentation update.

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

N/A