### PR TITLE
ci: run real studio e2e prep with bash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,7 @@ jobs:
 
       - name: Prepare real-project Sanity Studio E2E
         if: ${{ (steps.affected-presentation-e2e.outputs.run == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.run_real_studio) }}
+        shell: bash
         env:
           SANITY_E2E_PROJECT_ID: ${{ secrets.SANITY_E2E_PROJECT_ID }}
           SANITY_E2E_DATASET: ${{ secrets.SANITY_E2E_DATASET }}


### PR DESCRIPTION
## PR Checklist

Fixes the main CI failure in `presentation-e2e` where the `Prepare real-project Sanity Studio E2E` step runs under `sh` inside the Playwright container and fails on Bash indirect expansion with `Bad substitution`.

Closes N/A

## What is the new behavior?

The real-project Studio E2E preparation step now explicitly runs with Bash, so the existing `${!name}` secret-presence check is evaluated by the shell it was written for.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

No breaking change. This only updates the CI workflow shell for one preparation step.

## Other information

Validation performed:

- `bash -c 'missing=0; for name in SANITY_E2E_PROJECT_ID SANITY_E2E_DATASET SANITY_E2E_READ_TOKEN SANITY_E2E_BYPASS_TOKEN SANITY_E2E_STORAGE_STATE_JSON; do if [ -z "${!name}" ]; then missing=1; fi; done; test "$missing" -eq 1'`
- `pnpm exec prettier --check .github/workflows/ci.yml`
- `git diff --check`

## [Optional] What [gif](https://chrome.google.com/webstore/detail/gifs-for-github/dkgjnpbipbdaoaadbdhpiokaemhlphep) best describes this PR or how it makes you feel?

N/A
